### PR TITLE
Fix update summary for sparse updates

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src" "resources" "notebooks"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev {:extra-deps {org.clojure/clojure         {:mvn/version "1.11.1"}
-                              techascent/tech.ml.dataset  {:mvn/version "7.011"}
-                              scicloj/tablecloth          {:mvn/version "7.007"
+                              techascent/tech.ml.dataset  {:mvn/version "7.014"}
+                              scicloj/tablecloth          {:mvn/version "7.014"
                                                            :exclusions  [techascent/tech.ml.dataset
                                                                          org.apache.poi/poi-ooxml-schemas
                                                                          org.apache.poi/poi

--- a/notebooks/sen2_blade_csv_plans_placements.clj
+++ b/notebooks/sen2_blade_csv_plans_placements.clj
@@ -224,7 +224,7 @@
 ;; `plans-plaements-on-census-dates`.
 ;;
 ;; This step would likely be the first step of a namespace progressing
-;; towards a census, which  may also include programmatic updates for systematic
+;; towards a census, which may also include programmatic updates for systematic
 ;; issues as well as implementing updates entered in the #"`:update-.*`" columns of
 ;; the issues file using the code below.
 

--- a/notebooks/sen2_blade_csv_plans_placements.clj
+++ b/notebooks/sen2_blade_csv_plans_placements.clj
@@ -112,7 +112,8 @@
 
 ;;; ## 2. Extract plans & placements on census dates
 ^{::clerk/visibility {:code :hide}
-  ::clerk/viewer clerk/md ::clerk/no-cache true}
+  ::clerk/viewer clerk/md
+  ::clerk/no-cache true}
 ((comp :doc meta) #'sen2-blade-csv-plans-placements/plans-placements-on-census-dates)
 
 ;; Extract plans & placements on census dates (with person information)
@@ -266,7 +267,8 @@ sen2-blade-csv-plans-placements/cols-for-census
   (str wk-dir "plans-placements-on-census-dates-updates.csv"))
 
 ;; Read columns required into `plans-placements-on-census-dates-updates`:
-^{::clerk/visibility {:code :show, :result :hide}}
+^{::clerk/visibility {:code :show, :result :hide}
+  ::clerk/no-cache true}
 (def plans-placements-on-census-dates-updates
   (sen2-blade-csv-plans-placements/updates-csv-file->ds plans-placements-on-census-dates-updates-filepath))
 

--- a/src/witan/sen2/return/person_level/blade_export/csv/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade_export/csv/plans_placements.clj
@@ -18,8 +18,8 @@
   "Person ID columns to carry through from `person` table (in addition to `:person-table-id`)."
   [:person-order-seq-column :upn :unique-learner-number])
 
-(def sen2-establishment-keys
-  "Sen2 establishment column keywords from `placement-detail` table"
+(def sen2-estab-keys
+  "SEN2 establishment column keywords from `placement-detail` table"
   [:urn :ukprn :sen-unit-indicator :resourced-provision-indicator :sen-setting])
 
 (def cols-for-census
@@ -28,7 +28,7 @@
                     [:requests-table-id]
                     [:census-year :census-date]
                     [#_:age-at-start-of-school-year :ncy-nominal]
-                    sen2-establishment-keys
+                    sen2-estab-keys
                     [:sen-type])))
 
 
@@ -254,7 +254,7 @@
                                                                  :placement-detail-table-id :placement-detail-order-seq-column
                                                                  :census-date
                                                                  :entry-date :leaving-date :placement-rank]
-                                                                sen2-establishment-keys
+                                                                sen2-estab-keys
                                                                 [:sen-setting-other])))
                            (tc/add-column :placement-detail? true)
                            (tc/set-dataset-name "placement-detail"))
@@ -530,7 +530,7 @@
                                      ;; Placement info from SEN2 `placement-detail` module
                                      [:placement-detail?
                                       :placement-rank :entry-date :leaving-date]
-                                     sen2-establishment-keys
+                                     sen2-estab-keys
                                      ;; SEN need info from SEN2 `sen-need` module
                                      [:sen-need?
                                       :sen-type])))

--- a/src/witan/sen2/return/person_level/blade_export/csv/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade_export/csv/plans_placements.clj
@@ -672,7 +672,7 @@
       (tc/update-columns #"^:update-[^\?]*" (partial map #(if (some? %) "Δ" " ")))
       (tc/group-by [:census-date :update-drop? :update-ncy-nominal :update-sen2-establishment :update-sen-type])
       (tc/aggregate {:row-count tc/row-count})
-      (tc/pivot->wider :census-date :row-count)
+      (tc/pivot->wider :census-date :row-count {:drop-missing? false})
       (tc/rename-columns {:update-drop?              "drop?"
                           :update-ncy-nominal        "Nominal NCY"
                           :update-sen2-establishment "SEN2 Establishment"


### PR DESCRIPTION
Summary of combination of updates by `:census-date` was using
`pivot->wider` without the `{:drop-missing? false}` option, so was
dropping rows where the particular update combination was not present
for all `:census-date`s.

Also:
- Bump dev deps for TC & TMD
- Rename `sen2-establishment-keys` -> `sen2-estab-keys`
- Add `::clerk/no-cache` to update read