### PR TITLE
Updates to plan-placement CSV file handling

### DIFF
--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -50,13 +50,13 @@
 
 (def plans-placements-on-census-dates-col-name->label
   "Column labels for display."
-  sen2-blade-plans-placements/plans-placements-on-census-dates-col-name->label)
+  (delay sen2-blade-plans-placements/plans-placements-on-census-dates-col-name->label))
 
 ;;; ## Write plans & placements file
 (comment
   (let [ds              @plans-placements-on-census-dates
         file-name-stem  (tc/dataset-name ds)
-        col-name->label plans-placements-on-census-dates-col-name->label]
+        col-name->label @plans-placements-on-census-dates-col-name->label]
     (tc/write! (tc/dataset {:column-number (iterate inc 1)
                             :column-name   (map name   (tc/column-names ds))
                             :column-label  (map col-name->label (tc/column-names ds))})
@@ -82,15 +82,14 @@
 
 (def plans-placements-on-census-dates-issues-col-name->label
   "Column labels for display."
-  (sen2-blade-plans-placements/plans-placements-on-census-dates-issues-col-name->label
-   checks))
+  (delay (sen2-blade-plans-placements/plans-placements-on-census-dates-issues-col-name->label checks)))
 
 
 ;;; ### Write issues file
 (comment
   (let [ds              @plans-placements-on-census-dates-issues
         file-name-stem  (tc/dataset-name ds)
-        col-name->label plans-placements-on-census-dates-issues-col-name->label]
+        col-name->label @plans-placements-on-census-dates-issues-col-name->label]
     (tc/write! (tc/dataset {:column-number (iterate inc 1)
                             :column-name   (map name   (tc/column-names ds))
                             :column-label  (map col-name->label (tc/column-names ds))})

--- a/templates/plans_placements_eda.clj
+++ b/templates/plans_placements_eda.clj
@@ -97,7 +97,7 @@ plans-placements/census-dates-ds
 
 ^{::clerk/viewer (partial clerk/table {::clerk/width :full})}
 (column-info-with-labels @plans-placements/plans-placements-on-census-dates
-                         plans-placements/plans-placements-on-census-dates-col-name->label)
+                         @plans-placements/plans-placements-on-census-dates-col-name->label)
 
 ^{::clerk/viewer clerk/md}
 (format "Wrote `%s`  \nto working directory: %s:"
@@ -111,7 +111,7 @@ plans-placements/census-dates-ds
 ;; `plans-placements-on-census-dates-issues` dataset structure:
 ^{::clerk/viewer (partial clerk/table {::clerk/width :full})}
 (column-info-with-labels @plans-placements/plans-placements-on-census-dates-issues
-                         plans-placements/plans-placements-on-census-dates-issues-col-name->label)
+                         @plans-placements/plans-placements-on-census-dates-issues-col-name->label)
 
 ^{::clerk/viewer clerk/md}
 (format "Wrote `%s`  \nto working directory: %s:"


### PR DESCRIPTION
- Define parser-fn for reading plan-placement CSVs locally
  - Rather than collating from `sen2-blade-csv`, to reduce dependencies and so consistent across SEN2 Blade Exports and other SEN2 submission/pre-submission data.
  - Allow specification of read options to …csv-file->ds functions.
- Replace checks and delta chars in issues summary with "X" and "*" for consistent fixed-width display spacing.
- Put `def`s calling `…col-name->label` fns on a delay (in templates) so consistent.