### PR TITLE
Remove CSV specific aspects so more generic

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,17 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
-                  :extra-deps  {techascent/tech.ml.dataset  {:mvn/version "7.021"}
-                                scicloj/tablecloth          {:mvn/version "7.021"
-                                                             :exclusions  [techascent/tech.ml.dataset
-                                                                           org.apache.poi/poi-ooxml-schemas
-                                                                           org.apache.poi/poi
-                                                                           org.apache.poi/poi-ooxml]}
-                                ;; Clerk only required to run the template namespaces and notebooks. Not required by src namespaces.
-                                io.github.nextjournal/clerk {:mvn/version "0.15.957"}}}
+                  :extra-deps  {techascent/tech.ml.dataset               {:mvn/version "7.021"}
+                                scicloj/tablecloth                       {:mvn/version "7.021"
+                                                                          :exclusions  [techascent/tech.ml.dataset
+                                                                                        org.apache.poi/poi-ooxml-schemas
+                                                                                        org.apache.poi/poi
+                                                                                        org.apache.poi/poi-ooxml]}
+                                ;; adroddiad & clerk only required to run the template namespaces and notebooks. Not required by src namespaces.
+                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "5301bb7f3b5abdcd207f40d9d99752b4972a1638"
+                                                                           :exclusions [mastodonc/witan.send
+                                                                                        techascent/tech.ml.dataset]}
+                                io.github.nextjournal/clerk              {:mvn/version "0.15.957"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {techascent/tech.ml.dataset {:mvn/version "7.021"}
                                 scicloj/tablecloth         {:mvn/version "7.021"

--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -2,7 +2,7 @@
   "Extract & check plans & placements on census dates from SEN2 Blade."
   (:require [tablecloth.api :as tc]
             [witan.sen2 :as sen2]
-            [witan.sen2.return.person-level.blade.csv :as sen2-blade-csv]
+            [sen2-blade :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.plans-placements :as sen2-blade-plans-placements]))
 
 
@@ -19,38 +19,17 @@
   (sen2/census-years->census-dates-ds [2022 2023]))
 
 
-;;; ## SEN2 Blade
-(def sen2-blade-export-dir
-  "Directory containing SEN2 Blade export files"
-  "./data/example-sen2-blade-csv-export/")
-
-(def sen2-blade-export-date-string
-  "Date (string) of COLLECT `Blade-Export`"
-  "31-03-2023")
-
-
-
-;;; # Read CSV files
-(def sen2-blade-csv-file-paths
-  "Map of the SEN2 Blade export CSV file paths."
-  (sen2-blade-csv/file-paths sen2-blade-export-dir
-                             sen2-blade-export-date-string))
-
-(def sen2-blade-csv-ds-map
-  "Map of SEN2 Blade export CSV datasets."
-  (delay (sen2-blade-csv/file-paths->ds-map sen2-blade-csv-file-paths)))
-
-
 
 ;;; # Extract plans & placements on census dates
 (def plans-placements-on-census-dates
   "Plans & placements on census dates (with person information)."
-  (delay (sen2-blade-plans-placements/plans-placements-on-census-dates @sen2-blade-csv-ds-map
+  (delay (sen2-blade-plans-placements/plans-placements-on-census-dates @sen2-blade/ds-map
                                                                        census-dates-ds)))
 
 (def plans-placements-on-census-dates-col-name->label
   "Column labels for display."
   (delay sen2-blade-plans-placements/plans-placements-on-census-dates-col-name->label))
+
 
 ;;; ## Write plans & placements file
 (comment

--- a/templates/sen2_blade.clj
+++ b/templates/sen2_blade.clj
@@ -1,0 +1,43 @@
+(ns sen2-blade
+  "SEN2 Blade read from COLLECT Blade CSV export."
+  (:require [witan.sen2.return.person-level.blade.csv :as sen2-blade-csv]))
+
+
+
+;;; # Parameters
+;;; ## SEN2 Blade
+(def export-dir
+  "Directory containing SEN2 Blade export files"
+  "./data/example-sen2-blade-csv-export/")
+
+(def export-date-string
+  "Date (string) of COLLECT `Blade-Export`"
+  "31-03-2023")
+
+
+
+;;; # Read SEN2 Blade from CSV files
+(def csv-file-paths
+  "Map of the SEN2 Blade export CSV file paths."
+  (sen2-blade-csv/file-paths export-dir
+                             export-date-string))
+
+(def ds-map
+  "Map of SEN2 Blade datasets."
+  (delay (sen2-blade-csv/file-paths->ds-map csv-file-paths)))
+
+(def table-id-ds
+  "Dataset of `:*table-id` key relationships."
+  (delay (sen2-blade-csv/ds-map->table-id-ds @sen2-blade/ds-map)))
+
+
+;;; ## Bring in defs required for EDA/documentation
+;; Not required of not doing a sen2-blade-eda.
+(def module-titles
+  sen2-blade-csv/module-titles)
+
+(def module-col-name->label
+  sen2-blade-csv/module-col-name->label)
+
+(def module-src-col-name->col-name
+  sen2-blade-csv/module-src-col-name->col-name)

--- a/templates/sen2_blade_eda.clj
+++ b/templates/sen2_blade_eda.clj
@@ -1,5 +1,5 @@
-(ns sen2-blade-csv-eda
-  "EDA of SEN2 Blade read from from SEN2 Blade CSV export."
+(ns sen2-blade-eda
+  "EDA of SEN2 Blade."
   {:nextjournal.clerk/toc                  true
    :nextjournal.clerk/visibility           {:code   :hide
                                             :result :show}
@@ -9,8 +9,7 @@
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
-            [tablecloth.api :as tc]
-            [witan.sen2.return.person-level.blade.csv :as sen2-blade-csv]
+            [sen2-blade :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]))
 
 ^{;; Notebook header
@@ -31,24 +30,21 @@
 (def out-dir
   "Output directory"
   "./tmp/")
-^{::clerk/visibility {:result :show}, ::clerk/viewer clerk/md}
+
+^{::clerk/viewer clerk/md}
 (format "%s: `%s`." ((comp :doc meta) #'out-dir) out-dir)
 
 
-;;; ### SEN2 Blade Export
-^{::clerk/visibility {:result :hide}}
-(def sen2-blade-export-dir
-  "Directory containing SEN2 Blade CSV export."
-  "./data/example-sen2-blade-csv-export/")
-^{::clerk/viewer clerk/md}
-(format "%s:  \n`%s`." ((comp :doc meta) #'sen2-blade-export-dir) sen2-blade-export-dir)
-
-^{::clerk/visibility {:result :hide}}
-(def sen2-blade-export-date-string
-  "Date (string) of COLLECT `Blade-Export`"
-  "31-03-2023")
-^{::clerk/viewer clerk/md}
-(format "%s: `%s`." ((comp :doc meta) #'sen2-blade-export-date-string) sen2-blade-export-date-string)
+;;; ### SEN2 Blade
+;; Read from:
+^{::clerk/viewer (partial clerk/table {::clerk/width :prose})}
+#_(-> sen2-blade/sen2-blade-csv-file-paths
+      ((fn [m] (tc/dataset {"Module key" (keys m)
+                            "File Path"  (vals m)}))))
+(into [["Module Key" "File Path" "Exists?"]]
+      (map (fn [[k v]]
+             [k v (if (.exists (io/file v)) "✅" "❌")]))
+      sen2-blade/csv-file-paths)
 
 ;; NOTE: The `person` module should be de-identified as follows:
 ;; - [x] Contents of the `surname` field deleted.
@@ -61,37 +57,12 @@
 
 
 
-;;; ## Read CSV files
-^{::clerk/visibility {:result :hide}}
-(def sen2-blade-csv-file-names
-  "Map of the SEN2 Blade CSV export file names."
-  (sen2-blade-csv/file-names sen2-blade-export-date-string))
-
-^{::clerk/viewer (partial clerk/table {::clerk/width :prose})}
-(into [["Key" "File Name" "Exists?"]]
-      (map (fn [[k v]]
-             (let [path (str sen2-blade-export-dir v)]
-               [k v (if (.exists (io/file path)) "✅" "❌")])))
-      sen2-blade-csv-file-names)
-
-^{::clerk/visibility {:result :hide}}
-(def sen2-blade-csv-file-paths
-  "Map of the SEN2 Blade CSV export file paths."
-  (update-vals sen2-blade-csv-file-names (partial str sen2-blade-export-dir)))
-
-^{::clerk/visibility {:result :hide}}
-(def sen2-blade-csv-ds-map
-  "Map of SEN2 Blade datasets read from Blade CSV export."
-  (sen2-blade-csv/file-paths->ds-map sen2-blade-csv-file-paths))
-
-
-
 ;;; ## Dataset structure & categorical values
 (sen2-blade-eda/report-all-module-info
- sen2-blade-csv-ds-map
- {:module-titles                       sen2-blade-csv/module-titles
-  :module-col-name->label              sen2-blade-csv/module-col-name->label
-  :module-src-col-name->col-name       sen2-blade-csv/module-src-col-name->col-name})
+ @sen2-blade/ds-map
+ {:module-titles                       sen2-blade/module-titles
+  :module-col-name->label              sen2-blade/module-col-name->label
+  :module-src-col-name->col-name       sen2-blade/module-src-col-name->col-name})
 
 
 
@@ -100,30 +71,23 @@
 (sen2-blade-eda/report-table-keys)
 
 
-
-;;; ## `*-table-id` Key relationships
+;;; ### `*-table-id` Key relationships
 ;; The hierarchy is proper (due to COLLECT):
 ;; - primary keys are unique
 ;; - all foreign keys in child are contained in parent
 ;; - not all parent records have children
 ;; - some parents have multiple children
-(sen2-blade-eda/report-key-relationships sen2-blade-csv-ds-map)
+(sen2-blade-eda/report-key-relationships @sen2-blade/ds-map)
 
 
-
-;;; ## `table-id-ds`
-^{::clerk/visibility {:result :hide}}
-(def sen2-blade-csv-table-id-ds
-  "Dataset of `:*table-id` key relationships."
-  (sen2-blade-csv/ds-map->table-id-ds sen2-blade-csv-ds-map))
-
-(sen2-blade-eda/report-table-id-ds sen2-blade-csv-table-id-ds)
+;;; ### `table-id-ds`
+(sen2-blade-eda/report-table-id-ds @sen2-blade/table-id-ds)
 
 
 
 ;;; ## Composite keys
 ;; Note: OK if not a unique key without `requests-table-id`,
-(sen2-blade-eda/report-composite-keys sen2-blade-csv-ds-map)
+(sen2-blade-eda/report-composite-keys @sen2-blade/ds-map)
 
 
 


### PR DESCRIPTION
Remove CSV specific aspects where unnecessary yielding more generic code that can be used for SEN2 Blade data read from other file formats.
- Add template `sen2-blade` ns to read SEN2 Blade in one place.
