### PR TITLE
Update checks of plans & placements

### DIFF
--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -51,7 +51,7 @@
 ;;; # Check for issues
 (def checks
   "Definitions for checks for issues in dataset of plans & placements on census dates."
-  sen2-blade-plans-placements/checks)
+  (sen2-blade-plans-placements/checks))
 
 (def plans-placements-on-census-dates-issues
   "Selected columns of the `plans-placements-on-census-dates` dataset,


### PR DESCRIPTION
- change check `:col-fn`s from function applied to entire dataset but expected to only add a single appropriately named `:issue-*` column to function to be used within `tc/add-column`, so: clear are just adding an issues column; simpler to specify; and more robust as with this formulation cannot mess up the rest of the plans & placements dataset or mis-sepcify the name of the `:issue-*` column.
- add `:cols-required` to check definition and update `flag-issues` to only run a check if those columns are present. This allows checks to be run on plans & placements after applying updates, when only key columns are retained.
- extend checks: note that some checks on full plans & placements overlap (eg. a `:issue-unknown-age-at-start-of-school-year` will result in a `:issue-missing-ncy-nominal`): this is intentional and is to ensure appropriate checking of plans & placements after applying updates.
- simplify reporting of issues, including separating out the specification of the totals.
- make `checks` a function and allow specification of allowable `sen-types` and `sen-settings`, the latter so that updates can (ab)use :sen-setting to specify :estab-cat at placement level without being flagged as an issue by checks.
- drop 1-arity versions of functions that had `checks` as optional 2nd argument and require `checks` are always passed as a parameter.