### PR TITLE
Add ancestor `:*-table-id`s to COLLECT Blade CSV read

### DIFF
--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -15,7 +15,7 @@
 
 ;;; ## Census dates
 (def census-dates-ds
-  "Dataset with column `:census-date` of dates to extract open plans & placements on"
+  "Dataset with column `:census-date` of dates to extract open plans & placements on."
   (sen2/census-years->census-dates-ds [2022 2023]))
 
 
@@ -49,10 +49,15 @@
 
 
 ;;; # Check for issues
+
+
+;;; ## Checks
 (def checks
   "Definitions for checks for issues in dataset of plans & placements on census dates."
   (sen2-blade-plans-placements/checks))
 
+
+;;; ## Run checks
 (def plans-placements-on-census-dates-issues
   "Selected columns of the `plans-placements-on-census-dates` dataset,
    for rows with issues flagged by `checks`,

--- a/templates/sen2_blade.clj
+++ b/templates/sen2_blade.clj
@@ -30,13 +30,13 @@
   "Map of SEN2 Blade datasets."
   (delay (sen2-blade-csv/file-paths->ds-map file-paths)))
 
-(def table-id-ds
-  "Dataset of `:*table-id` key relationships."
-  (delay (sen2-blade-csv/ds-map->table-id-ds @sen2-blade/ds-map)))
-
 
 ;;; ## Bring in defs required for EDA/documentation
-;; Not required of not doing a sen2-blade-eda.
+;; Not required if not doing a sen2-blade-eda.
+(def table-id-ds
+  "Dataset of `:*table-id` key relationships."
+  (delay (sen2-blade-csv/ds-map->table-id-ds @ds-map)))
+
 (def module-titles
   sen2-blade-csv/module-titles)
 
@@ -45,3 +45,4 @@
 
 (def module-src-col-name->col-name
   sen2-blade-csv/module-src-col-name->col-name)
+

--- a/templates/sen2_blade_eda.clj
+++ b/templates/sen2_blade_eda.clj
@@ -66,16 +66,20 @@
 
 ;;; ## Database structure
 (sen2-blade-eda/report-expected-schema)
-(sen2-blade-eda/report-table-keys)
 
 
-;;; ### `*-table-id` Key relationships
+
+;;; ## COLLECT `:*-table-id`s
+(sen2-blade-eda/report-collect-keys)
+
+
+;;; ### Table relationships by COLLECT `:*-table-id`
 ;; The hierarchy is proper (due to COLLECT):
 ;; - primary keys are unique
 ;; - all foreign keys in child are contained in parent
 ;; - not all parent records have children
 ;; - some parents have multiple children
-(sen2-blade-eda/report-key-relationships @sen2-blade/ds-map)
+(sen2-blade-eda/report-collect-key-relationships @sen2-blade/ds-map)
 
 
 ;;; ### `table-id-ds`
@@ -83,9 +87,18 @@
 
 
 
-;;; ## Composite keys
-;; Note: OK if not a unique key without `requests-table-id`,
-(sen2-blade-eda/report-composite-keys @sen2-blade/ds-map)
+;;; ## `:person-table-id` & `:requests-table-id`
+;; For person, named-plan, placement-detail & sen-need modules with ancestor `:*-table-id`s.
+
+
+;;; ### Table relationships by `:person-table-id` & `:requests-table-id`
+(sen2-blade-eda/report-key-relationships @sen2-blade/ds-map)
+
+
+;;; ### Unique keys
+;; Note: Except for `person`, OK if not a unique key without `requests-table-id`,
+(sen2-blade-eda/report-unique-keys @sen2-blade/ds-map)
+(sen2-blade-eda/report-table-keys)
 
 
 


### PR DESCRIPTION
So that:
- Easier to use the sen2-blade modules as all chidren of the requests table have `:person-id` & `:requests-id`.
- Matches the SEN2 Blades extracted from LA precursor Excel files, which have datasets keyed by `:person-id` & `:requests-id`.
- Removes requirement to merge in ancestor `:*-table-id`s from a table-id-ds in witan.sen2.return.person-level.blade.plans-placements.
- Removes requirement for witan.sen2.return.person-level.blade.csv in witan.sen2.return.person-level.blade.eda & witan.sen2.return.person-level.blade.plans-placements.
- Results in witan.sen2.return.person-level.blade.eda & witan.sen2.return.person-level.blade.plans-placements code that can be be used without modification for SEN2 Blades extracted from sources other than a COLLECT CSV export (such as LA pre-submission workbooks).
