### PR TITLE
Update to read SEN2 COLLECT export v1.2 (for 2024 SEN2 returns)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
-                  :extra-deps  {techascent/tech.ml.dataset               {:mvn/version "7.029"}
+                  :extra-deps  {techascent/tech.ml.dataset               {:mvn/version "7.021"}
                                 scicloj/tablecloth                       {:mvn/version "7.021"
                                                                           :exclusions  [techascent/tech.ml.dataset
                                                                                         org.apache.poi/poi-ooxml-schemas
@@ -13,7 +13,7 @@
                                                                                         techascent/tech.ml.dataset]}
                                 io.github.nextjournal/clerk              {:mvn/version "0.15.957"}}}
            :test {:extra-paths ["test"]
-                  :extra-deps  {techascent/tech.ml.dataset {:mvn/version "7.029"}
+                  :extra-deps  {techascent/tech.ml.dataset {:mvn/version "7.021"}
                                 scicloj/tablecloth         {:mvn/version "7.021"
                                                             :exclusions  [techascent/tech.ml.dataset
                                                                           org.apache.poi/poi-ooxml-schemas

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
                   :extra-deps  {techascent/tech.ml.dataset               {:mvn/version "7.029"}
-                                scicloj/tablecloth                       {:mvn/version "7.029.2"
+                                scicloj/tablecloth                       {:mvn/version "7.021"
                                                                           :exclusions  [techascent/tech.ml.dataset
                                                                                         org.apache.poi/poi-ooxml-schemas
                                                                                         org.apache.poi/poi
@@ -14,7 +14,7 @@
                                 io.github.nextjournal/clerk              {:mvn/version "0.15.957"}}}
            :test {:extra-paths ["test"]
                   :extra-deps  {techascent/tech.ml.dataset {:mvn/version "7.029"}
-                                scicloj/tablecloth         {:mvn/version "7.029.2"
+                                scicloj/tablecloth         {:mvn/version "7.021"
                                                             :exclusions  [techascent/tech.ml.dataset
                                                                           org.apache.poi/poi-ooxml-schemas
                                                                           org.apache.poi/poi

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
-                  :extra-deps  {techascent/tech.ml.dataset               {:mvn/version "7.021"}
-                                scicloj/tablecloth                       {:mvn/version "7.021"
+                  :extra-deps  {techascent/tech.ml.dataset               {:mvn/version "7.029"}
+                                scicloj/tablecloth                       {:mvn/version "7.029.2"
                                                                           :exclusions  [techascent/tech.ml.dataset
                                                                                         org.apache.poi/poi-ooxml-schemas
                                                                                         org.apache.poi/poi
@@ -13,8 +13,8 @@
                                                                                         techascent/tech.ml.dataset]}
                                 io.github.nextjournal/clerk              {:mvn/version "0.15.957"}}}
            :test {:extra-paths ["test"]
-                  :extra-deps  {techascent/tech.ml.dataset {:mvn/version "7.021"}
-                                scicloj/tablecloth         {:mvn/version "7.021"
+                  :extra-deps  {techascent/tech.ml.dataset {:mvn/version "7.029"}
+                                scicloj/tablecloth         {:mvn/version "7.029.2"
                                                             :exclusions  [techascent/tech.ml.dataset
                                                                           org.apache.poi/poi-ooxml-schemas
                                                                           org.apache.poi/poi

--- a/src/witan/sen2/return/person_level/blade/csv.clj
+++ b/src/witan/sen2/return/person_level/blade/csv.clj
@@ -149,7 +149,8 @@
    "surname"              :surname
    "forename"             :forename
    "personbirthdate"      :person-birth-date
-   "gendercurrent"        :gender-current
+   "gendercurrent"        :gender-current ; <v1.2
+   "sex"                  :sex            ; ≥v1.2
    "ethnicity"            :ethnicity
    "postcode"             :postcode
    "upn"                  :upn
@@ -166,7 +167,8 @@
    :surname                 :string
    :forename                :string
    :person-birth-date       [:local-date parse-date]
-   :gender-current          :string
+   :gender-current          :string     ; <v1.2
+   :sex                     :string     ; ≥v1.2
    :ethnicity               :string
    :postcode                :string
    :upn                     :string
@@ -189,7 +191,8 @@
    :surname                 "Surname"
    :forename                "Forename"
    :person-birth-date       "Date of birth"
-   :gender-current          "Gender"
+   :gender-current          "Gender"    ; <v1.2
+   :sex                     "Sex"       ; ≥v1.2
    :ethnicity               "Ethnicity"
    :postcode                "Post code"
    :upn                     "UPN – Unique Pupil Number"
@@ -421,8 +424,10 @@
    "sourceid"                  :source-id
    "requeststableid"           :requests-table-id
    "transferla"                :transfer-la
-   "res"                       :res
-   "wbp"                       :wbp
+   "res"                       :res            ; <v1.2
+   "wbp"                       :wbp            ; <v1.2
+   "reviewmeeting"             :review-meeting ; ≥v1.2
+   "reviewoutcome"             :review-outcome ; ≥v1.2
    "lastreview"                :last-review})
 
 (def active-plans-parser-fn
@@ -433,8 +438,10 @@
    :source-id                     :string
    :requests-table-id             :string
    :transfer-la                   :string
-   :res                           :string
-   :wbp                           :string
+   :res                           :string                  ; <v1.2
+   :wbp                           :string                  ; <v1.2
+   :review-meeting                [:local-date parse-date] ; ≥v1.2
+   :review-outcome                :string                  ; ≥v1.2
    :last-review                   [:local-date parse-date]})
 
 (def active-plans-read-cfg
@@ -451,9 +458,12 @@
    :source-id                     "Source ID"
    :requests-table-id             "Requests table ID"
    :transfer-la                   "EHC plan transferred in from another LA during calendar year"
-   :res                           "Residential settings"
-   :wbp                           "Work-based learning activity"
-   :last-review                   "EHC plan review decisions date"})
+   :res                           "Residential settings"          ; <v1.2
+   :wbp                           "Work-based learning activity"  ; <v1.2
+   :review-meeting                "Annual review meeting date"    ; ≥v1.2
+   :review-outcome                "Annual review decision"        ; ≥v1.2
+   :last-review                   "Annual review decision date"   ; ≥v1.2: "EHC plan review decisions date" ; <v1.2
+   })
 
 
 ;;; ## Module 5b: Placements - Placement details (`placement-detail`)
@@ -464,6 +474,8 @@
    "placementdetailorderseqcolumn" :placement-detail-order-seq-column
    "sourceid"                      :source-id
    "activeplanstableid"            :active-plans-table-id
+   "res"                           :res                ; ≥v1.2
+   "wbp"                           :wbp                ; ≥v1.2
    "urn"                           :urn
    "ukprn"                         :ukprn
    "sensetting"                    :sen-setting
@@ -471,7 +483,7 @@
    "placementrank"                 :placement-rank
    "entrydate"                     :entry-date
    "leavingdate"                   :leaving-date
-   "attendancepattern"             :attendance-pattern
+   "attendancepattern"             :attendance-pattern ; <v1.2
    "senunitindicator"              :sen-unit-indicator
    "resourcedprovisionindicator"   :resourced-provision-indicator})
 
@@ -482,6 +494,8 @@
    :placement-detail-order-seq-column :int32
    :source-id                         :string
    :active-plans-table-id             :string
+   :res                               :string ; ≥v1.2
+   :wbp                               :string ; ≥v1.2
    :urn                               :string
    :ukprn                             :string
    :sen-setting-other                 :string
@@ -491,7 +505,8 @@
    :sen-unit-indicator                :boolean
    :resourced-provision-indicator     :boolean
    :sen-setting                       :string
-   :attendance-pattern                :string})
+   :attendance-pattern                :string ; <v1.2
+   })
 
 (def placement-detail-read-cfg
   "Configuration map for reading SEN2 module 5b \"Placement details\" into a dataset."
@@ -506,6 +521,8 @@
    :placement-detail-order-seq-column "Placement detail order seq column"
    :source-id                         "Source ID"
    :active-plans-table-id             "Active plans table ID"
+   :res                               "Residential settings"         ; ≥v1.2
+   :wbp                               "Work-based learning activity" ; ≥v1.2
    :urn                               "URN – Unique Reference Number"
    :ukprn                             "UKPRN – UK Provider Reference Number"
    :sen-setting                       "SEN Setting - Establishment type"
@@ -513,7 +530,7 @@
    :placement-rank                    "Placement rank"
    :entry-date                        "Placement start date"
    :leaving-date                      "Placement leaving date"
-   :attendance-pattern                "Attendance pattern"
+   :attendance-pattern                "Attendance pattern" ; <v1.2
    :sen-unit-indicator                "SEN Unit indicator"
    :resourced-provision-indicator     "Resourced provision indicator"})
 

--- a/src/witan/sen2/return/person_level/blade/eda.clj
+++ b/src/witan/sen2/return/person_level/blade/eda.clj
@@ -44,8 +44,8 @@
   [ds cols]
   (reduce 
    (fn [m k] 
-     (merge m 
-            {k (frequencies (ds k))}))
+     (merge m
+            (when (ds k) {k (frequencies (ds k))})))
    {}
    cols))
 
@@ -66,7 +66,8 @@
                       :surname
                       :forename
                       #_:person-birth-date
-                      :gender-current
+                      :gender-current   ; <v1.2
+                      :sex              ; ≥v1.2
                       #_:ethnicity
                       #_:postcode
                       #_:upn
@@ -127,14 +128,18 @@
                       :source-id
                       #_:requests-table-id
                       :transfer-la
-                      :res
-                      :wbp
+                      :res              ; <v1.2
+                      :wbp              ; <v1.2
+                      #_:review-meeting ; ≥v1.2
+                      :review-outcome   ; ≥v1.2
                       #_:last-review]
    :placement-detail [#_:placement-detail-table-id
                       :native-id
                       #_:placement-detail-order-seq-column
                       :source-id
                       #_:active-plans-table-id
+                      :res              ; ≥v1.2
+                      :wbp              ; ≥v1.2
                       #_:urn
                       #_:ukprn
                       :sen-setting
@@ -142,7 +147,7 @@
                       :placement-rank
                       #_:entry-date
                       #_:leaving-date
-                      :attendance-pattern
+                      :attendance-pattern ; <v1.2
                       :sen-unit-indicator
                       :resourced-provision-indicator]
    :sen-need         [#_:sen-need-table-id

--- a/src/witan/sen2/return/person_level/blade/eda.clj
+++ b/src/witan/sen2/return/person_level/blade/eda.clj
@@ -58,6 +58,7 @@
 
 (def default-module-cols-to-report-distinct-vals
   "Default map of columns to report distinct values for for each module."
+  ;; Columns considered but excluded are retained in the code but ignored using #_.
   {:person           [#_:person-table-id
                       :native-id
                       #_:person-order-seq-column

--- a/src/witan/sen2/return/person_level/dictionary.clj
+++ b/src/witan/sen2/return/person_level/dictionary.clj
@@ -5,7 +5,7 @@
 
   See in particular:
   - [Special educational needs survey: guide to submitting data](https://www.gov.uk/guidance/special-educational-needs-survey)
-  - [Special educational needs person level survey 2023: guide](https://www.gov.uk/government/publications/special-educational-needs-person-level-survey-2023-guide)
+  - [Special educational needs person level survey 2024: guide v1.1](https://assets.publishing.service.gov.uk/media/65786511095987001295dee0/2024_SEN2_Person_level_-_Guide_Version_1.1.pdf)
   - [Special educational needs person level survey: technical specification](https://www.gov.uk/government/publications/special-educational-needs-person-level-survey-technical-specification)")
 
 
@@ -28,36 +28,47 @@
 
 
 
-;;; # SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.5c of the DfE 2023 SEN2 return.
+;;; # SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.7c of the DfE 2024 SEN2 return.
 (def sen-setting
-  "SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.5c of the DfE 2023 SEN2 return."
+  "SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.7c of the DfE 2024 SEN2 return."
   (let [m {"OLA"  {:order       1
                    :label       "Other LA Arrangements (inc. EOTAS)"
-                   :description (str "Other – arrangements made by the local authority "
-                                     "in accordance with section 61 of the Children and Families Act 2014, "
-                                     "(\"education otherwise than at a school or post-16 institution etc\").")}
+                   :description (str "Other - arrangements made by the local authority "
+                                     "in accordance with section 61 of the 2014 Act, "
+                                     "(\"Special education provision otherwise than in schools, post-16 institution etc\", "
+                                     "commonly referred to as EOTAS) "
+                                     "- for example therapy that is special educational provision for a child "
+                                     "and where it would be inappropriate to provide this in a school.")}
            "OPA"  {:order       2
                    :label       "Other Parent/Person Arrangements (exc. EHE)"
                    :description (str "Other – alternative arrangements made by parents or young person "
-                                     "in accordance with section 42(5) of the Children and Families Act 2014, "
-                                     "excluding those who are subject to elective home education.")}
+                                     "in accordance with section 42(5) of the 2014 Act, "
+                                     "excluding those who are subject to elective home education. "
+                                     "(For example where parents have chosen to arrange and pay for an independent school placement.)")}
            "EHE"  {:order       3
                    :label       "Elective Home Education"
-                   :description (str "Elective home education – alternative arrangements made by parents or young person "
-                                     "in accordance with section 42(5) of the Children and Families Act 2014, for elective home education.")}
+                   :description (str "Elective home education - alternative arrangements "
+                                     "made by parents or young person "
+                                     "in accordance with section 42(5) of the 2014 Act "
+                                     "for elective home education.")}
            "EYP"  {:order       4
                    :label       "Early Years Provider"
                    :description (str "Early years provider with no GIAS URN "
                                      "(for example private nursery, independent early years providers and childminders).")}
-           "NEET" {:order       5
-                   :label       "Not in Education, Training or Employment"
-                   :description (str "Not in education, training or employment (aged 16-25).")}
-           "NIEC" {:order       6
-                   :label       "Ceasing"
-                   :description (str "Not in education or training – Notice to cease issued.")}
-           "NIEO" {:order       7
+           "OTH"  {:order       5
                    :label       "Other"
-                   :description (str "Not in education – Other – "
+                   :description (str "Other - Includes where a type of setting is specified in the EHC plan "
+                                     "(e.g., special school) but no specific setting is named. "
+                                     "Where this is used, the local authority will be prompted for further information in COLLECT.")}
+           "NEET" {:order       6
+                   :label       "Not in education, employment or training - Aged 16-25"
+                   :description (str "Not in education, employment, or training (aged 16-25).")}
+           "NIEC" {:order       7
+                   :label       "Not in education or training - Ceasing"
+                   :description (str "Not in education or training – Notice to cease issued.")}
+           "NIEO" {:order       8
+                   :label       "Not in education or training - Other"
+                   :description (str "Not in education or training - Other - "
                                      "Where this is used, the local authority will be prompted for further information in COLLECT, "
                                      "for example, transferred into the local authority with an EHC plan and awaiting placement.")}}]
     (into (sorted-map-by (partial compare-get-in m :order)) m)))


### PR DESCRIPTION
Update for SEN2 updates 2023 (v1.1) → 2024 (v1.2):
- New:
  - 5.4: Annual review meeting date <ReviewMeeting>
  - 5.5: Annual review decision <ReviewOutcome>
- Changed
  - 5.4 (2023 v1.0) EHC plan review decisions date <LastReview> → (2024 v1.1) 5.6 Annual review decision date <LastReview> (same data and column name but different title and now mandatory)
  - 1.4 (2023 v1.0): Gender {0,1,2,9} → 1.4 Sex {"M", "F"}
  - 4.7 (2023 v1.0, actually 5.5c) Definition NIEO was (2023 v1.0 5.5c) "Not in education - Other" now (2024 v1.1 5.7c) "Not in education or training - Other".
  - 5.5c (2023 v1.0) placementDetail <SENsetting> now (2023 v1.1 5.7c) includes "OTH".
  - 5.2 <Res> & 5.3 <WBP> exported in "activeplans" in 2023 but now (correctly) in "placementdetail".
- Removed:
  - 5.5g (2023 v1.0): attendance pattern <AttendancePatttern>