### PR TITLE
SEN2 2025

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure        {:mvn/version "1.11.1"}
-           techascent/tech.ml.dataset {:mvn/version "7.029"}
+           techascent/tech.ml.dataset {:mvn/version "7.030"}
            scicloj/tablecloth         {:mvn/version "7.029.2"
                                        :exclusions  [techascent/tech.ml.dataset
                                                      org.apache.poi/poi-ooxml-schemas

--- a/deps.edn
+++ b/deps.edn
@@ -8,8 +8,8 @@
                                                      org.apache.poi/poi-ooxml]}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
                   :extra-deps  {;; adroddiad & clerk only required to run the template namespaces and notebooks. Not required by src namespaces.
-                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "5301bb7f3b5abdcd207f40d9d99752b4972a1638"
+                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "a24132375b066ec17af257a6646a4c187ac76afa"
                                                                            :exclusions [mastodonc/witan.send
                                                                                         techascent/tech.ml.dataset]}
-                                io.github.nextjournal/clerk               {:mvn/version "0.15.957"}}}
+                                io.github.nextjournal/clerk               {:mvn/version "0.17.1102"}}}
            :test {:extra-paths ["test"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
                                                      org.apache.poi/poi-ooxml]}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
                   :extra-deps  {;; adroddiad & clerk only required to run the template namespaces and notebooks. Not required by src namespaces.
-                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "a24132375b066ec17af257a6646a4c187ac76afa"
+                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "b30989f12aefb57bada69c75e9cf39469fdd869b"
                                                                            :exclusions [mastodonc/witan.send
                                                                                         techascent/tech.ml.dataset]}
                                 io.github.nextjournal/clerk               {:mvn/version "0.17.1102"}}}

--- a/src/witan/sen2/return/person_level/blade/eda.clj
+++ b/src/witan/sen2/return/person_level/blade/eda.clj
@@ -59,7 +59,7 @@
 (def default-module-cols-to-report-distinct-vals
   "Default map of columns to report distinct values for for each module."
   ;; Columns considered but excluded are retained in the code but ignored using #_.
-  {:person           [:record-type      ; template only
+  {:person           [:record-type                          ; template only
                       #_:person-table-id
                       :native-id
                       #_:person-order-seq-column
@@ -68,27 +68,28 @@
                       :surname
                       :forename
                       #_:person-birth-date
-                      :gender-current   ; <v1.2
-                      :sex              ; ≥v1.2
+                      :gender-current                       ; <v1.2
+                      :sex                                  ; ≥v1.2
                       #_:ethnicity
                       #_:postcode
                       #_:upn
                       #_:unique-learner-number
                       :upn-unknown]
-   :requests         [:record-type      ; template only
+   :requests         [:record-type                          ; template only
                       #_:requests-table-id
                       :native-id
                       #_:requests-order-seq-column
                       :source-id
                       #_:person-table-id
                       #_:received-date
+                      :request-source                       ; ≥v1.3
                       :rya
                       #_:request-outcome-date
                       :request-outcome
                       :request-mediation
                       :request-tribunal
                       :exported]
-   :assessment       [:record-type      ; template only
+   :assessment       [:record-type                          ; template only
                       #_:assessment-table-id
                       :native-id
                       #_:assessment-order-seq-column
@@ -101,7 +102,7 @@
                       :other-mediation
                       :other-tribunal
                       :week20]
-   :named-plan       [:record-type      ; template only
+   :named-plan       [:record-type                          ; template only
                       #_:named-plan-table-id
                       :native-id
                       #_:named-plan-order-seq-column
@@ -115,7 +116,7 @@
                       :dp
                       #_:cease-date
                       :cease-reason]
-   :plan-detail      [:record-type      ; template only
+   :plan-detail      [:record-type                          ; template only
                       #_:plan-detail-table-id
                       :native-id
                       #_:plan-detail-order-seq-column
@@ -128,26 +129,27 @@
                       :placement-rank
                       :sen-unit-indicator
                       :resourced-provision-indicator]
-   :active-plans     [:record-type      ; template only
+   :active-plans     [:record-type                          ; template only
                       #_:active-plans-table-id
                       :native-id
                       #_:active-plans-order-seq-column
                       :source-id
                       #_:requests-table-id
                       :transfer-la
-                      :res              ; <v1.2
-                      :wbp              ; <v1.2
-                      #_:review-meeting ; ≥v1.2
-                      :review-outcome   ; ≥v1.2
+                      :res                                  ; <v1.2
+                      :wbp                                  ; <v1.2
+                      #_:review-meeting                     ; ≥v1.2
+                      :review-outcome                       ; ≥v1.2
+                      #_:review-draft                       ; ≥v1.3
+                      #_:phase-transfer-due-date            ; ≥v1.3
+                      #_:phase-transfer-final-date          ; ≥v1.3
                       #_:last-review]
-   :placement-detail [:record-type      ; template only
+   :placement-detail [:record-type                          ; template only
                       #_:placement-detail-table-id
                       :native-id
                       #_:placement-detail-order-seq-column
                       :source-id
                       #_:active-plans-table-id
-                      :res              ; ≥v1.2
-                      :wbp              ; ≥v1.2
                       #_:urn
                       #_:ukprn
                       :sen-setting
@@ -155,10 +157,13 @@
                       :placement-rank
                       #_:entry-date
                       #_:leaving-date
-                      :attendance-pattern ; <v1.2
+                      :attendance-pattern                   ; <v1.2
                       :sen-unit-indicator
-                      :resourced-provision-indicator]
-   :sen-need         [:record-type      ; template only
+                      :resourced-provision-indicator
+                      :res                                  ; ≥v1.2
+                      :wbp                                  ; ≥v1.2
+                      ]
+   :sen-need         [:record-type                          ; template only
                       #_:sen-need-table-id
                       :native-id
                       #_:sen-need-order-seq-column

--- a/src/witan/sen2/return/person_level/dictionary.clj
+++ b/src/witan/sen2/return/person_level/dictionary.clj
@@ -5,7 +5,7 @@
 
   See in particular:
   - [Special educational needs survey: guide to submitting data](https://www.gov.uk/guidance/special-educational-needs-survey)
-  - [Special educational needs person level survey 2024: guide v1.1](https://assets.publishing.service.gov.uk/media/65786511095987001295dee0/2024_SEN2_Person_level_-_Guide_Version_1.1.pdf)
+  - [Special educational needs person level survey 2025: guide v1.4](https://assets.publishing.service.gov.uk/media/675831b5f72b1d96e06bbfdf/SEN_survey_-_guide_to_person_level_SEN2_return_2025.pdf)
   - [Special educational needs person level survey: technical specification](https://www.gov.uk/government/publications/special-educational-needs-person-level-survey-technical-specification)")
 
 
@@ -28,26 +28,26 @@
 
 
 
-;;; # SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.7c of the DfE 2024 SEN2 return.
+;;; # SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.7c of the DfE 2025 SEN2 return.
 (def sen-setting
-  "SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.7c of the DfE 2024 SEN2 return."
+  "SEN setting - Establishment type <SENsetting>, per items 4.7c & 5.7c of the DfE 2025 SEN2 return."
   (let [m {"OLA"  {:order       1
                    :label       "Other LA Arrangements (inc. EOTAS)"
-                   :description (str "Other - arrangements made by the local authority "
+                   :description (str "Other – arrangements made by the local authority "
                                      "in accordance with section 61 of the 2014 Act, "
-                                     "(\"Special education provision otherwise than in schools, post-16 institution etc\", "
+                                     "(\"Special educational provision otherwise than in schools, post-16 institutions etc\", "
                                      "commonly referred to as EOTAS) "
                                      "- for example therapy that is special educational provision for a child "
-                                     "and where it would be inappropriate to provide this in a school.")}
+                                     "and where it would be inappropriate to provide this in any school etc.")}
            "OPA"  {:order       2
                    :label       "Other Parent/Person Arrangements (exc. EHE)"
                    :description (str "Other – alternative arrangements made by parents or young person "
                                      "in accordance with section 42(5) of the 2014 Act, "
-                                     "excluding those who are subject to elective home education. "
-                                     "(For example where parents have chosen to arrange and pay for an independent school placement.)")}
+                                     "excluding those who are subject to elective home education "
+                                     "(for example, where parents have chosen to arrange and pay for an independent school placement).")}
            "EHE"  {:order       3
                    :label       "Elective Home Education"
-                   :description (str "Elective home education - alternative arrangements "
+                   :description (str "Elective home education – alternative arrangements "
                                      "made by parents or young person "
                                      "in accordance with section 42(5) of the 2014 Act "
                                      "for elective home education.")}
@@ -57,18 +57,18 @@
                                      "(for example private nursery, independent early years providers and childminders).")}
            "OTH"  {:order       5
                    :label       "Other"
-                   :description (str "Other - Includes where a type of setting is specified in the EHC plan "
+                   :description (str "Other – Includes where a type of setting is specified in the EHC plan "
                                      "(e.g., special school) but no specific setting is named. "
                                      "Where this is used, the local authority will be prompted for further information in COLLECT.")}
            "NEET" {:order       6
-                   :label       "Not in education, employment or training - Aged 16-25"
+                   :label       "Not in education, employment or training – Aged 16-25"
                    :description (str "Not in education, employment, or training (aged 16-25).")}
            "NIEC" {:order       7
-                   :label       "Not in education or training - Ceasing"
+                   :label       "Not in education or training – Ceasing"
                    :description (str "Not in education or training – Notice to cease issued.")}
            "NIEO" {:order       8
-                   :label       "Not in education or training - Other"
-                   :description (str "Not in education or training - Other - "
+                   :label       "Not in education or training – Other"
+                   :description (str "Not in education or training – Other – "
                                      "Where this is used, the local authority will be prompted for further information in COLLECT, "
                                      "for example, transferred into the local authority with an EHC plan and awaiting placement.")}}]
     (into (sorted-map-by (partial compare-get-in m :order)) m)))
@@ -79,7 +79,7 @@
 
 
 
-;;; # EHCP needs <SENtype>, per item 5.6 of the DfE 2023 SEN2 return.
+;;; # EHCP needs <SENtype>, per item 5.8a of the DfE 2025 SEN2 return.
 (def sen-type
   (let [m {"SPLD" {:order 1
                    :name  "Specific learning difficulty"
@@ -114,7 +114,10 @@
            "ASD"  {:order 11
                    :name  "Autistic spectrum disorder"
                    :label "Autistic Spectrum Disorder"}
-           "OTH"  {:order 12
+           "DS"   {:order 12
+                   :name  "Down Syndrome"
+                   :label "Down Syndrome"}
+           "OTH"  {:order 13
                    :name  "Other difficulty"
                    :label "Other Difficulty"}}]
     (into (sorted-map-by (partial compare-get-in m :order)) m)))

--- a/templates/sen2_blade_csv.clj
+++ b/templates/sen2_blade_csv.clj
@@ -8,11 +8,13 @@
 ;;; ## SEN2 Blade
 (def data-dir
   "Directory containing SEN2 Blade export files"
-  "./data/example-sen2-blade-csv-export/")
+  #_"./data/example-sen2-blade-csv-export-2023/"
+  "./data/example-sen2-blade-csv-export-2024/")
 
 (def export-date-string
   "Date (string) of COLLECT `Blade-Export`"
-  "31-03-2023")
+  #_"31-03-2023"
+  "18-04-2024")
 
 
 

--- a/templates/sen2_blade_csv_eda.clj
+++ b/templates/sen2_blade_csv_eda.clj
@@ -1,44 +1,47 @@
 (ns sen2-blade-csv-eda
   "EDA of SEN2 Blade read from COLLECT Blade CSV export."
-  {:nextjournal.clerk/toc                  true
-   :nextjournal.clerk/visibility           {:code   :hide
-                                            :result :show}
-   :nextjournal.clerk/page-size            nil
-   :nextjournal.clerk/auto-expand-results? true
-   :nextjournal.clerk/budget               nil}
+  #:nextjournal.clerk{:toc                  true
+                      :visibility           {:code :hide, :result :hide}
+                      :page-size            nil
+                      :auto-expand-results? true
+                      :budget               nil}
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
             [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]))
 
-^{;; Notebook header
-  ::clerk/no-cache true}
-(clerk/md (str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
-               "# witan.sen2"
-               (format "  \n`%s`  \n" *ns*)
-               ((comp :doc meta) *ns*)
-               "  \nTimeStamp: " (.format (java.time.LocalDateTime/now)
-                                          (java.time.format.DateTimeFormatter/ISO_LOCAL_DATE_TIME))))
+
+(def client-name      "Mastodon C")
+(def workpackage-name "witan.sen2")
+(def out-dir "Output directory" "./tmp/")
+
+^#::clerk{:visibility {:result :show},:viewer clerk/md, :no-cache true} ; Notebook header
+(str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
+     (format "# %s SEND %s  \n" client-name workpackage-name)
+     (format "`%s`\n\n" *ns*)
+     (format "%s\n\n" ((comp :doc meta) *ns*))
+     (format "Produced: `%s`\n\n"  (.format (java.time.LocalDateTime/now)
+                                            (java.time.format.DateTimeFormatter/ofPattern "dd-MMM-uuuu HH:mm:ss"
+                                                                                          (java.util.Locale. "en_GB")))))
+
+(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
+{::clerk/visibility {:result :show}}
+
 
 
 
 ;;; # SEN2 Blade EDA
 ;;; ## Parameters
 ;;; ### Output directory
-^{::clerk/visibility {:result :hide}}
-(def out-dir
-  "Output directory"
-  "./tmp/")
-
-^{::clerk/viewer clerk/md}
-(format "%s: `%s`." ((comp :doc meta) #'out-dir) out-dir)
+^#::clerk{:viewer clerk/md}
+(doc-var #'out-dir)
 
 
 ;;; ### SEN2 Blade
-^{::clerk/viewer clerk/md}
+^#::clerk{:viewer clerk/md}
 (format "Read from: `%s`:" sen2-blade/data-dir)
-^{::clerk/viewer (partial clerk/table {::clerk/width :prose})}
+^#::clerk{:viewer (partial clerk/table {::clerk/width :prose})}
 (into [["Module Key" "File Name" "Exists?"]]
       (map (fn [[k v]]
              [k v (if (.exists (io/file (str sen2-blade/data-dir v))) "✅" "❌")]))
@@ -103,13 +106,15 @@
 
 
 
-^{::clerk/visibility {:result :hide}}
+^#::clerk{:visibility {:result :hide}}
 (comment ;; clerk build
-  (let [in-path            (str "templates/" (clojure.string/replace (str *ns*) #"\.|-" {"." "/" "-" "_"}) ".clj")
-        out-path           (str out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html")]
-    (clerk/build! {:paths    [in-path]
-                   :ssr      true
-                   :bundle   true
-                   :out-path "."})
+  (let [in-path  (str "templates/" (clojure.string/replace (str *ns*) #"\.|-" {"." "/" "-" "_"}) ".clj")
+        out-path (str out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html")]
+    (clerk/build! {:paths      [in-path]
+                   :ssr        true
+                   #_#_:bundle true         ; clerk v0.15.957
+                   :package    :single-file ; clerk v0.16.1016
+                   :out-path   "."})
     (.renameTo (io/file "./index.html") (io/file out-path)))
+
   )

--- a/templates/sen2_blade_template_eda.clj
+++ b/templates/sen2_blade_template_eda.clj
@@ -1,42 +1,44 @@
 (ns sen2-blade-template-eda
   "EDA of SEN2 Blade read from Excel submission template."
-  {:nextjournal.clerk/toc                  true
-   :nextjournal.clerk/visibility           {:code   :hide
-                                            :result :show}
-   :nextjournal.clerk/page-size            nil
-   :nextjournal.clerk/auto-expand-results? true
-   :nextjournal.clerk/budget               nil}
+  #:nextjournal.clerk{:toc                  true
+                      :visibility           {:code :hide, :result :hide}
+                      :page-size            nil
+                      :auto-expand-results? true
+                      :budget               nil}
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
             [sen2-blade-template :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]))
 
-^{;; Notebook header
-  ::clerk/no-cache true}
-(clerk/md (str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
-               "# witan.sen2"
-               (format "  \n`%s`  \n" *ns*)
-               ((comp :doc meta) *ns*)
-               "  \nTimeStamp: " (.format (java.time.LocalDateTime/now)
-                                          (java.time.format.DateTimeFormatter/ISO_LOCAL_DATE_TIME))))
+(def client-name      "Mastodon C")
+(def workpackage-name "witan.sen2")
+(def out-dir "Output directory" "./tmp/")
+
+^#::clerk{:visibility {:result :show},:viewer clerk/md, :no-cache true} ; Notebook header
+(str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
+     (format "# %s SEND %s  \n" client-name workpackage-name)
+     (format "`%s`\n\n" *ns*)
+     (format "%s\n\n" ((comp :doc meta) *ns*))
+     (format "Produced: `%s`\n\n"  (.format (java.time.LocalDateTime/now)
+                                            (java.time.format.DateTimeFormatter/ofPattern "dd-MMM-uuuu HH:mm:ss"
+                                                                                          (java.util.Locale. "en_GB")))))
+
+(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
+{::clerk/visibility {:result :show}}
+
 
 
 
 ;;; # SEN2 Blade EDA
 ;;; ## Parameters
 ;;; ### Output directory
-^{::clerk/visibility {:result :hide}}
-(def out-dir
-  "Output directory"
-  "./tmp/")
-
-^{::clerk/viewer clerk/md}
-(format "%s: `%s`." ((comp :doc meta) #'out-dir) out-dir)
+^#::clerk{:viewer clerk/md}
+(doc-var #'out-dir)
 
 
 ;;; ### SEN2 Blade
-^{::clerk/viewer clerk/md}
+^#::clerk{:viewer clerk/md}
 (format "%s:  \n`%s`."
         ((comp :doc meta) #'sen2-blade/template-filepath)
         sen2-blade/template-filepath)
@@ -83,11 +85,13 @@
 
 ^{::clerk/visibility {:result :hide}}
 (comment ;; clerk build
-  (let [in-path            (str "templates/" (clojure.string/replace (str *ns*) #"\.|-" {"." "/" "-" "_"}) ".clj")
-        out-path           (str out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html")]
-    (clerk/build! {:paths    [in-path]
-                   :ssr      true
-                   :bundle   true
-                   :out-path "."})
+  (let [in-path  (str "templates/" (clojure.string/replace (str *ns*) #"\.|-" {"." "/" "-" "_"}) ".clj")
+        out-path (str out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html")]
+    (clerk/build! {:paths      [in-path]
+                   :ssr        true
+                   #_#_:bundle true         ; clerk v0.15.957
+                   :package    :single-file ; clerk v0.16.1016
+                   :out-path   "."})
     (.renameTo (io/file "./index.html") (io/file out-path)))
+
   )


### PR DESCRIPTION
Updates for 2025 SEN2 return
- Add Down Syndrome (DS) to needs.
- Additional data items for 2025 (per §1.12 of 2025 SEN2 Guide)
  - Add "Designated Social Care Officer" as `:dsco` (:string) to module `sen2`.
  - Add item 2.2 "Source of request for an EHC needs assessment" <RequestSource> as `:request-source` (:int8) to `requests` module.
  - Add item 5.4d "Annual review – date draft amended EHC plan issued" <ReviewDraft> as `:review-draft` (:local-date) to `active-plans` module.
  - Add item 5.6a "Phase transfer review - due date for any amended plan" <PhaseTransferDueDate> as `:phase-transfer-due-date` (:local-date) to `active-plans` module.
  - Add item 5.6b "Phase transfer review - final plan date" <PhaseTransferFinalDate> as `:phase-transfer-final-date` (:local-date) to `active-plans` module.
- plus:
  - Replace sen2 module "DMO" & "DCO" labels with "Designated Medical Officer" & "Designated Clinical Officer".
  - Reordered fields to match order in XML specification.

Note that implemeting this in advance of receiving 2025 SEN2 Blade CSV exports or templates, using expected column names from the technical specification.
