### PR TITLE
Update templates

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,16 @@
 {:paths   ["src" "resources"]
- :deps    {org.clojure/clojure             {:mvn/version "1.11.4"}
-           techascent/tech.ml.dataset      {:mvn/version "7.059"}
-           scicloj/tablecloth              {:mvn/version "7.059"
+ :deps    {org.clojure/clojure             {:mvn/version "1.12.3"}
+           techascent/tech.ml.dataset      {:mvn/version "7.066"}
+           scicloj/tablecloth              {:mvn/version "7.062"
                                             :exclusions  [techascent/tech.ml.dataset
                                                           org.apache.poi/poi-ooxml-schemas
                                                           org.apache.poi/poi
                                                           org.apache.poi/poi-ooxml]}
-           com.github.MastodonC/witan.gias {:git/sha "763874c49256ca51c508c28952480356e644dea9"}}
+           com.github.MastodonC/witan.gias {:git/sha "aaecb96d94a5e7a6b2d3aa36c617570d897f2d9c"}}
  :aliases {:dev  {:extra-paths ["templates" "dev"]
                   :extra-deps  {;; adroddiad & clerk only required to run the template namespaces and notebooks. Not required by src namespaces.
-                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "fe464c39dd53cea4498dbcd5e08a24d05bf32fd4"
+                                com.github.MastodonC/witan.send.adroddiad {:git/sha    "1cf2e3293d5e16330c4dc06a2ee989068ebee7be"
                                                                            :exclusions [mastodonc/witan.send
                                                                                         techascent/tech.ml.dataset]}
-                                io.github.nextjournal/clerk               {:mvn/version "0.17.1102"}}}
+                                io.github.nextjournal/clerk               {:mvn/version "0.18.1142"}}}
            :test {:extra-paths ["test"]}}}

--- a/src/witan/sen2.clj
+++ b/src/witan/sen2.clj
@@ -7,6 +7,12 @@
            [java.time.format DateTimeFormatter]))
 
 ;;; # SEN2 census dates
+(defn return-year->census-years
+  "Given year of a SEN2 return, returns vector containing the years of the two 
+   SEN2 census dates covered by the reporting period for that return."
+  [return-year]
+  ((juxt dec identity) return-year))
+
 (def census-year->date-string
   "Map SEN2 census year to census date (as ISO8601 date strings)"
   (sorted-map

--- a/src/witan/sen2.clj
+++ b/src/witan/sen2.clj
@@ -2,7 +2,9 @@
   "Special educational needs survey (SEN2) information
    from [gov.uk](https://www.gov.uk/guidance/special-educational-needs-survey)
    unless stated otherwise."
-  (:require [tablecloth.api :as tc]))
+  (:require [tablecloth.api :as tc])
+  (:import [java.time LocalDate]
+           [java.time.format DateTimeFormatter]))
 
 ;;; # SEN2 census dates
 (def census-year->date-string
@@ -26,9 +28,9 @@
 (def census-year->date
   "Map SEN2 census year to census date"
   (update-vals census-year->date-string
-               #(java.time.LocalDate/parse %
-                                           (java.time.format.DateTimeFormatter/ofPattern "uuuu-MM-dd"
-                                                                                         (java.util.Locale. "en_GB")))))
+               #(LocalDate/parse %
+                                 (DateTimeFormatter/ofPattern "uuuu-MM-dd"
+                                                              (java.util.Locale. "en_GB")))))
 
 (defn date->census-date
   "Given a date `d` and vector of `census-dates`, returns the (first) SEN2 census-date on or after that date.

--- a/src/witan/sen2/return/person_level/blade/eda.clj
+++ b/src/witan/sen2/return/person_level/blade/eda.clj
@@ -309,10 +309,10 @@
    (report-collect-key-relationship ds-map :requests         :person       :person-table-id       "(Should be 1+  per 2023 SEN2 guide v1.0 Module 2 description on p18.)")
    (report-collect-key-relationship ds-map :assessment       :requests     :requests-table-id     "(Should be 0-1 per 2023 SEN2 guide v1.0 Module 3 description on p21.)")
    (report-collect-key-relationship ds-map :named-plan       :assessment   :assessment-table-id   "(Should be 0-1 per 2023 SEN2 guide v1.0 Module 3 description on p21 & Module 4 description on p24.)")
-   (report-collect-key-relationship ds-map :plan-detail      :named-plan   :named-plan-table-id   "(Should be 1-2 per 2023 SEN2 guide v1.0 Module 4 <PlanDetail> description on p26.)")
-   (report-collect-key-relationship ds-map :active-plans     :requests     :requests-table-id     "(Should be 0-1 per 2023 SEN2 guide v1.0 Module 5 <ActivePlans> description on p28.)")
-   (report-collect-key-relationship ds-map :placement-detail :active-plans :active-plans-table-id "(Should be 1+  per 2023 SEN2 guide v1.0 Module 5 <PlacementDetail> description on p29.)")
-   (report-collect-key-relationship ds-map :sen-need         :active-plans :active-plans-table-id "(Should be 1-2 per 2023 SEN2 guide v1.0 Module 5 <SENtype> description on p31.)")))
+   (report-collect-key-relationship ds-map :plan-detail      :named-plan   :named-plan-table-id   "(Should be 1-2 per 2023 SEN2 guide v1.0 Module 4 `PlanDetail` description on p26.)")
+   (report-collect-key-relationship ds-map :active-plans     :requests     :requests-table-id     "(Should be 0-1 per 2023 SEN2 guide v1.0 Module 5 `ActivePlans` description on p28.)")
+   (report-collect-key-relationship ds-map :placement-detail :active-plans :active-plans-table-id "(Should be 1+  per 2023 SEN2 guide v1.0 Module 5 `PlacementDetail` description on p29.)")
+   (report-collect-key-relationship ds-map :sen-need         :active-plans :active-plans-table-id "(Should be 1-2 per 2023 SEN2 guide v1.0 Module 5 `SENtype` description on p31.)")))
 
 (defn report-table-id-ds
   [table-id-ds]

--- a/src/witan/sen2/return/person_level/blade/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade/plans_placements.clj
@@ -629,9 +629,9 @@
               :summary-label "#URNs"
               :action        "Confirm the placement-detail is correct or update."})
       (seq edubaseall-send-map) ; 53#: Add GIAS based checks for SENU & RP indicators if have GIAS SEND map:
-      (assoc :issue-senu-flagged-at-estab-without-one
+      (assoc :issue-unexpected-senu-indicated
              {:idx           532
-              :label         "SEN unit flagged at estab. other than URNs GIAS says has them."
+              :label         "SEN unit placement indicated at estab. other than URNs GIAS says has them."
               :cols-required #{:urn :sen-unit-indicator}
               :col-fn        (fn [{:keys [urn sen-unit-indicator]}]
                                (map #(and (->> %1
@@ -644,14 +644,14 @@
                                                true?))
                                     urn sen-unit-indicator))
               :summary-fn    (fn [ds] (-> ds
-                                          (tc/select-rows :issue-senu-flagged-at-estab-without-one)
+                                          (tc/select-rows :issue-unexpected-senu-indicated)
                                           (tc/unique-by [:urn :ukprn :sen-setting])
                                           tc/row-count))
               :summary-label "#Estabs"
               :action        "Review SEN unit flagging for these establishment(s) and correct if necessary."}
-             :issue-resourced-provision-flagged-at-estab-without-one
+             :issue-unexpected-rp-indicated
              {:idx           534
-              :label         "RP flagged at estab. other than URNs GIAS says has them."
+              :label         "RP placement indicated at estab. other than URNs GIAS says has them."
               :cols-required #{:urn :resourced-provision-indicator}
               :col-fn        (fn [{:keys [urn resourced-provision-indicator]}]
                                (map #(and (->> %1
@@ -664,7 +664,7 @@
                                                true?))
                                     urn resourced-provision-indicator))
               :summary-fn    (fn [ds] (-> ds
-                                          (tc/select-rows :issue-resourced-provision-flagged-at-estab-without-one)
+                                          (tc/select-rows :issue-unexpected-rp-indicated)
                                           (tc/unique-by [:urn :ukprn :sen-setting])
                                           tc/row-count))
               :summary-label "#Estabs"
@@ -927,8 +927,8 @@
    identify the issues, defaulting if not provided to the current default 
    `witan.gias/edubaseall-send->map`)."
   [ds & {:keys [issue-cols-selector census-year-col edubaseall-send-map]
-         :or   {issue-cols-selector [:issue-senu-flagged-at-estab-without-one
-                                     :issue-resourced-provision-flagged-at-estab-without-one]
+         :or   {issue-cols-selector [:issue-unexpected-senu-indicated
+                                     :issue-unexpected-rp-indicated]
                 census-year-col     (-> ds (tc/column-names [:census-year-* :census-year]) first)}}]
   (let [issue-cols          (tc/column-names ds issue-cols-selector)
         edubaseall-send-map (or edubaseall-send-map (gias/edubaseall-send->map))]

--- a/src/witan/sen2/return/person_level/blade/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade/plans_placements.clj
@@ -1250,40 +1250,44 @@
 
 
 ;;; # EDA
-(defn plan-placement-stats
+(defn plan-placement-module-summary
   "Given a `plans-placements-on-census-dates` dataset (possibly with records from
-   multiple returns identified by `:return-year`), summarises numbers of 
-   records with `:named-plan?` and/or `:placement-detail?` for each `:census-year`
-   (& `:return-year`), and adds on the published EHCP caseload for LA `la-name` 
-   for comparison."
+   multiple returns identified by `:return-year`), returns dataset summarising 
+   the numbers of records with `:named-plan?` and/or `:placement-detail?` for 
+   each `:census-year`, `:census-date` (& `:return-year`)."
+  [plans-placements-on-census-dates]
+  (-> plans-placements-on-census-dates
+      (tc/map-rows (fn [{:keys [named-plan? placement-detail?]}]
+                     {:num-plans              (if named-plan? 1 0)
+                      :num-placements         (if placement-detail? 1 0)
+                      :num-plan-or-placement  (if (or named-plan?
+                                                      placement-detail?) 1 0)
+                      :num-plan-and-placement (if (and named-plan?
+                                                       placement-detail?) 1 0)}))
+      (tc/group-by [:census-year :census-date :return-year])
+      (tc/aggregate-columns [:num-plans
+                             :num-placements
+                             :num-plan-or-placement
+                             :num-plan-and-placement]
+                            tcc/reduce-+)
+      (tc/order-by [:census-year :census-date :return-year])))
+
+(defn plan-placement-module-summary-with-caseload
+  "Given a `plans-placements-on-census-dates` dataset (possibly with records from
+   multiple returns identified by `:return-year`), returns dataset summarising 
+   the numbers of records with `:named-plan?` and/or `:placement-detail?` for 
+   each `:census-year`, `:census-date` (& `:return-year`) including the 
+   published EHCP caseload for LA `la-name` for comparison."
   [plans-placements-on-census-dates la-name]
-  (let [return-census-dates-ds (-> plans-placements-on-census-dates
-                                   (tc/select-columns [:census-year :census-date :return-year])
-                                   tc/unique-by
-                                   (tc/order-by [:census-year :census-date :return-year]))
-        stats                  (-> plans-placements-on-census-dates
-                                   (tc/map-rows (fn [{:keys [named-plan? placement-detail?]}]
-                                                  {:num-plans              (if named-plan? 1 0)
-                                                   :num-placements         (if placement-detail? 1 0)
-                                                   :num-plan-or-placement  (if (or named-plan?
-                                                                                   placement-detail?) 1 0)
-                                                   :num-plan-and-placement (if (and named-plan?
-                                                                                    placement-detail?) 1 0)}))
-                                   (tc/group-by [:census-year :return-year])
-                                   (tc/aggregate-columns [:num-plans
-                                                          :num-placements
-                                                          :num-plan-or-placement
-                                                          :num-plan-and-placement]
-                                                         tcc/reduce-+))
-        caseload               (-> (caseload/->ds)
-                                   (tc/select-rows #(-> %
-                                                        ((juxt :la-name :breakdown))
-                                                        (= [la-name "All EHC plans"])))
-                                   (tc/select-columns [:census-year :ehcplans]))]
-    (->  return-census-dates-ds
-         (tc/left-join stats [:census-year :return-year])
+  (let [caseload (-> (caseload/->ds)
+                     (tc/select-rows #(-> %
+                                          ((juxt :la-name :breakdown))
+                                          (= [la-name "All EHC plans"])))
+                     (tc/select-columns [:census-year :ehcplans]))]
+    (->  plans-placements-on-census-dates
+         plan-placement-module-summary
          (tc/left-join caseload [:census-year])
-         (tc/drop-columns #"^:.*\.(census|return)-year"))))
+         (tc/drop-columns #"^:.*\.(census-year|census-date|return-year)$"))))
 
 (def plan-placement-stats-col-name->label
   {:census-year            "Census Year"

--- a/src/witan/sen2/return/person_level/blade/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade/plans_placements.clj
@@ -334,6 +334,19 @@
            :placement-detail? "Got placement details from `placement-detail`?"
            :sen-need?         "Got an EHCP primary need from `sen-need`?"}))
 
+(defn csv-col-labels-dataset
+  "Given dataset and map mapping column names to labels, returns dataset with
+   columns `:column-number`, `:column-name` & `:column label` where any keyword 
+   column names are converted to names to match how `tc/write!` saves column
+   names in a CSV file."
+  [ds col-name->label]
+  (let [ds-col-names    (tc/column-names ds)
+        ds-dataset-name (tc/dataset-name ds)]
+    (tc/dataset {:column-number (iterate inc 1)
+                 :column-name   (map #(if (keyword? %) (name %) %) ds-col-names)
+                 :column-label  (map col-name->label ds-col-names)}
+                {:dataset-name (str ds-dataset-name "-col-labels")})))
+
 
 
 ;;; # Checks

--- a/src/witan/sen2/return/person_level/blade/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade/plans_placements.clj
@@ -156,7 +156,7 @@
   "
   [sen2-blade-ds-map census-dates-ds]
   (-> (sen2-blade-ds-map :placement-detail)
-      (extract-episodes-on-census-dates census-dates-ds :entry-date :leaving-date )
+      (extract-episodes-on-census-dates census-dates-ds :entry-date :leaving-date)
       ;; Add `:census-date-placement-idx` to index multiple placements in `:placement-rank` order.
       (tc/order-by [:person-table-id :requests-table-id :census-date :placement-rank])
       (tc/group-by [:person-table-id :requests-table-id :census-date])
@@ -260,13 +260,13 @@
         ;; As full (outer) join the join keys may be nil in either dataset so coalesce into single column.
         ((fn [ds] (cond-> ds
                     (contains? ds :placement-detail.sen2-table-id) ; May not have `:sen2-table-id`
-                    (tc/map-columns :sen2-table-id         [:sen2-table-id     :placement-detail.sen2-table-id    ] #(or %1 %2))
+                    (tc/map-columns :sen2-table-id         [:sen2-table-id     :placement-detail.sen2-table-id]     #(or %1 %2))
                     true
-                    (tc/map-columns :person-table-id       [:person-table-id   :placement-detail.person-table-id  ] #(or %1 %2))
+                    (tc/map-columns :person-table-id       [:person-table-id   :placement-detail.person-table-id]   #(or %1 %2))
                     true
                     (tc/map-columns :requests-table-id     [:requests-table-id :placement-detail.requests-table-id] #(or %1 %2))
                     true
-                    (tc/map-columns :census-date           [:census-date       :placement-detail.census-date      ] #(or %1 %2)))))
+                    (tc/map-columns :census-date           [:census-date       :placement-detail.census-date]       #(or %1 %2)))))
         (tc/drop-columns #"^:placement-detail\..+$")
         ;;
         ;; Merge in `sen-need` EHCP primary need (if available)
@@ -304,12 +304,12 @@
         (tc/drop-columns #"^:person\..+$")
         ;; Arrange dataset
         (tc/reorder-columns (distinct (concat sen2-blade-table-id-col-names
-                                              [                  ] (tc/column-names census-dates-ds)
-                                              [:person?          ] (sen2-blade-module-cols-to-select :person) [:age-at-start-of-school-year :ncy-nominal]
-                                              [:named-plan?      ] (sen2-blade-module-cols-to-select :named-plan)
-                                              [:active-plans?    ] (sen2-blade-module-cols-to-select :active-plans)
+                                              []                   (tc/column-names census-dates-ds)
+                                              [:person?]           (sen2-blade-module-cols-to-select :person) [:age-at-start-of-school-year :ncy-nominal]
+                                              [:named-plan?]       (sen2-blade-module-cols-to-select :named-plan)
+                                              [:active-plans?]     (sen2-blade-module-cols-to-select :active-plans)
                                               [:placement-detail?] (sen2-blade-module-cols-to-select :placement-detail)
-                                              [:sen-need?        ] (sen2-blade-module-cols-to-select :sen-need))))
+                                              [:sen-need?]         (sen2-blade-module-cols-to-select :sen-need))))
         (tc/order-by [:person-table-id :census-date :requests-table-id])
         (tc/set-dataset-name "plans-placements-on-census-dates"))))
 
@@ -727,8 +727,7 @@
    :total-row-count {:idx           998
                      :label         "TOTAL number of records"
                      :summary-fn    tc/row-count
-                     :summary-label "#rows"
-                     }
+                     :summary-label "#rows"}
    :total-num-cyp   {:idx           999
                      :label         "TOTAL number of CYP"
                      :summary-fn    (comp count distinct :person-table-id)
@@ -1097,7 +1096,7 @@
                 additional-val-cols]
          :or   {person-id-col-name :person-table-id}}]
   (-> ds
-      (tc/map-columns :val-col-name [:census-year :return-year] #(cond (= %1    %2   ) :census-year-return
+      (tc/map-columns :val-col-name [:census-year :return-year] #(cond (= %1    %2)    :census-year-return
                                                                        (= %1 (- %2 1)) :next-year-return
                                                                        :else           :other))
       (tc/join-columns :sen2-estab sen2-estab-keys {:result-type :map})

--- a/src/witan/sen2/return/person_level/blade/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade/plans_placements.clj
@@ -720,8 +720,8 @@
       ((fn [m] (into (sorted-map-by (fn [k1 k2] (compare [(get-in m [k1 :idx]) k1]
                                                          [(get-in m [k2 :idx]) k2]))) m))))))
 
-(def checks-totals
-  "Additional summaries of #rows and #CYP that can be merged onto checks."
+(def checks-total-issues
+  "Additional summaries of #rows and #CYP with issues that can be merged onto checks."
   {:issue-row-count {:idx           996
                      :label         "TOTAL number of records with issues flagged"
                      :summary-fn    #(-> %
@@ -736,8 +736,11 @@
                                          (tc/select-rows :issue?)
                                          (tc/unique-by [:person-table-id])
                                          tc/row-count)
-                     :summary-label "#CYP"}
-   :total-row-count {:idx           998
+                     :summary-label "#CYP"}})
+
+(def checks-total-records
+  "Additional summaries of #rows and #CYP that can be merged onto checks."
+  {:total-row-count {:idx           998
                      :label         "TOTAL number of records"
                      :summary-fn    tc/row-count
                      :summary-label "#rows"}
@@ -745,6 +748,11 @@
                      :label         "TOTAL number of CYP"
                      :summary-fn    (comp count distinct :person-table-id)
                      :summary-label "#CYP"}})
+
+(def checks-totals
+  "Additional summaries of #rows and #CYP with issues and in total that can be merged onto checks."
+  (merge checks-total-issues
+         checks-total-records))
 
 (defn flag-issues
   "Run `checks` on dataset `ds`, adding issue flag columns."

--- a/src/witan/sen2/return/person_level/blade/plans_placements.clj
+++ b/src/witan/sen2/return/person_level/blade/plans_placements.clj
@@ -1180,16 +1180,16 @@
   "Given the `census-year` (the year of the SEN2 census date of a plan/placement)
    and the SEN2 `return-year` from which the plan/placement was identified,
    returns a string indicating both:
-   - YYYY= indicates record for YYYY SEN2 census date
+   - YYYY# indicates record for YYYY SEN2 census date
            from year YYYY SEN2 return
            (i.e. the return for that year);
-   - YYYY+ indicates record for YYYY SEN2 census date
+   - YYYY~ indicates record for YYYY SEN2 census date
            from year YYYY + 1 SEN2 return 
            (i.e. the return for the following year)."
   [census-year return-year]
   (cond
-    (=      census-year  return-year) (str census-year "=")
-    (= (inc census-year) return-year) (str census-year "+")
+    (=      census-year  return-year) (str census-year "#")
+    (= (inc census-year) return-year) (str census-year "~")
     :else nil))
 
 (defn concat-plans-placements-on-census-dates
@@ -1203,10 +1203,10 @@
                       of the plan/placement and whether the record is from the 
                       SEN2 return for the same year or the SEN2 return for the
                       next year:
-                      - YYYY= indicates record for YYYY SEN2 census date
+                      - YYYY# indicates record for YYYY SEN2 census date
                               from year YYYY SEN2 return
                               (i.e. the return for that year);
-                      - YYYY+ indicates record for YYYY SEN2 census date
+                      - YYYY~ indicates record for YYYY SEN2 census date
                               from year YYYY + 1 SEN2 return 
                               (i.e. the return for the following year)."
   [xs]

--- a/src/witan/sen2/return/person_level/blade/template.clj
+++ b/src/witan/sen2/return/person_level/blade/template.clj
@@ -22,7 +22,7 @@
   [s]
   (->> s parse-double (format "%.0f")))
 
-(defn- parse-boolean
+(defn- parse-float-string-to-boolean
   "Function to parse \"0.0\" & \"1.0\" `s` to boolean."
   [s]
   (get {"0.0" false "1.0" true} s s))
@@ -287,11 +287,11 @@
    :person-table-id               [:string parse-id]
    :received-date                 [:local-date parse-date]
    :request-source                [:int8 parse-double]      ; ≥v1.3
-   :rya                           [:boolean parse-boolean]
+   :rya                           [:boolean parse-float-string-to-boolean]
    :request-outcome-date          [:local-date parse-date]
    :request-outcome               :string
-   :request-mediation             [:boolean parse-boolean]
-   :request-tribunal              [:boolean parse-boolean]
+   :request-mediation             [:boolean parse-float-string-to-boolean]
+   :request-tribunal              [:boolean parse-float-string-to-boolean]
    :exported                      :string})
 
 (def requests-base-read-cfg
@@ -348,11 +348,11 @@
    :requests-table-id               [:string parse-id]
    :assessment-outcome              :string
    :assessment-outcome-date         [:local-date parse-date]
-   :assessment-mediation            [:boolean parse-boolean]
-   :assessment-tribunal             [:boolean parse-boolean]
-   :other-mediation                 [:boolean parse-boolean]
-   :other-tribunal                  [:boolean parse-boolean]
-   :week20                          [:boolean parse-boolean]})
+   :assessment-mediation            [:boolean parse-float-string-to-boolean]
+   :assessment-tribunal             [:boolean parse-float-string-to-boolean]
+   :other-mediation                 [:boolean parse-float-string-to-boolean]
+   :other-tribunal                  [:boolean parse-float-string-to-boolean]
+   :week20                          [:boolean parse-float-string-to-boolean]})
 
 (def assessment-base-read-cfg
   "Base configuration map (without `:start-row` or `:end-row`) for reading SEN2 module 3 \"EHC needs assessments\" into a dataset."
@@ -412,8 +412,8 @@
    :start-date                      [:local-date parse-date]
    :plan-res                        :string
    :plan-wbp                        :string
-   :pb                              [:boolean parse-boolean]
-   :oa                              [:boolean parse-boolean]
+   :pb                              [:boolean parse-float-string-to-boolean]
+   :oa                              [:boolean parse-float-string-to-boolean]
    :dp                              :string
    :cease-date                      [:local-date parse-date]
    :cease-reason                    [:int8 parse-double]})
@@ -478,8 +478,8 @@
    :ukprn                            [:string parse-id]
    :sen-setting                      :string
    :sen-setting-other                :string
-   :sen-unit-indicator               [:boolean parse-boolean]
-   :resourced-provision-indicator    [:boolean parse-boolean]
+   :sen-unit-indicator               [:boolean parse-float-string-to-boolean]
+   :resourced-provision-indicator    [:boolean parse-float-string-to-boolean]
    :placement-rank                   [:int8 parse-double]})
 
 (def plan-detail-base-read-cfg
@@ -618,8 +618,8 @@
    :entry-date                            [:local-date parse-date]
    :leaving-date                          [:local-date parse-date]
    :attendance-pattern                    :string ; <v1.2
-   :sen-unit-indicator                    [:boolean parse-boolean]
-   :resourced-provision-indicator         [:boolean parse-boolean]
+   :sen-unit-indicator                    [:boolean parse-float-string-to-boolean]
+   :resourced-provision-indicator         [:boolean parse-float-string-to-boolean]
    :res                                   :string ; ≥v1.2
    :wbp                                   :string ; ≥v1.2
    })

--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -14,15 +14,19 @@
   "Output directory"
   "./tmp/")
 
+(def census-years
+  "Years of SEN2 census dates on which to extract plans & placements."
+  (-> @sen2-blade/return-year sen2/return-year->census-years))
+
 (def sen2-blade-suffix
   "Suffix (to identify source SEN2 blade) to append to dataset and output file names."
-  "-2024")
+  (str "-" @sen2-blade/return-year))
 
 
 ;;; ## Census dates
 (def census-dates-ds
   "Dataset with column `:census-date` of dates to extract open plans & placements on."
-  (sen2/census-years->census-dates-ds [2022 2023]))
+  (sen2/census-years->census-dates-ds census-years))
 
 
 

--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -15,7 +15,7 @@
 
 (def sen2-blade-suffix
   "Suffix (to identify source SEN2 blade) to append to dataset and output file names."
-  "-2025")
+  "-2024")
 
 
 ;;; ## Census dates

--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -1,8 +1,9 @@
 (ns plans-placements
   "Extract & check plans & placements on census dates from SEN2 Blade."
   (:require [tablecloth.api :as tc]
+            [witan.gias :as gias]
             [witan.sen2 :as sen2]
-            [sen2-blade :as sen2-blade] ; <- replace with workpackage specific version
+            [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.plans-placements :as sen2-blade-plans-placements]))
 
 
@@ -11,6 +12,10 @@
 (def out-dir
   "Output directory"
   "./tmp/")
+
+(def sen2-blade-suffix
+  "Suffix (to identify source SEN2 blade) to append to dataset and output file names."
+  "-2025")
 
 
 ;;; ## Census dates
@@ -21,10 +26,19 @@
 
 
 ;;; # Extract plans & placements on census dates
+(def sen2-blade-module-cols-to-select
+  "Map of SEN2 Blade columns to select for inclusion from each module (in addition to `:*-table-id` cols)."
+  (-> sen2-blade-plans-placements/sen2-blade-module-cols-to-select
+      ;; Add `:res` & `:wbp` from `placement-detail` module
+      (update :placement-detail #(conj % :res :wbp))))
+
 (def plans-placements-on-census-dates
   "Plans & placements on census dates (with person information)."
-  (delay (sen2-blade-plans-placements/plans-placements-on-census-dates @sen2-blade/ds-map
-                                                                       census-dates-ds)))
+  (delay (-> @sen2-blade/ds-map
+             (sen2-blade-plans-placements/plans-placements-on-census-dates
+              census-dates-ds
+              {:sen2-blade-module-cols-to-select sen2-blade-module-cols-to-select})
+             (as-> $ (tc/set-dataset-name $ (str (tc/dataset-name $) sen2-blade-suffix))))))
 
 (def plans-placements-on-census-dates-col-name->label
   "Column labels for display."
@@ -33,26 +47,58 @@
           sen2-blade/module-col-name->label)))
 
 
-;;; ## Write plans & placements file
-(comment
-  (let [ds              @plans-placements-on-census-dates
-        file-name-stem  (tc/dataset-name ds)
-        col-name->label @plans-placements-on-census-dates-col-name->label]
-    (tc/write! (tc/dataset {:column-number (iterate inc 1)
-                            :column-name   (map name   (tc/column-names ds))
-                            :column-label  (map col-name->label (tc/column-names ds))})
-               (str out-dir file-name-stem "-col-labels.csv"))
-    (tc/write! ds
-               (str out-dir file-name-stem ".csv")))
+(comment ;; Write plans & placements file (and column labels file)
+  (do (-> @plans-placements-on-census-dates
+          (#(tc/write! % (str out-dir (tc/dataset-name %) ".csv"))))
+      (-> @plans-placements-on-census-dates
+          (sen2-blade-plans-placements/csv-col-labels-dataset
+           @plans-placements-on-census-dates-col-name->label)
+          (#(tc/write! % (str out-dir (tc/dataset-name %) ".csv")))))
   )
 
 
 
 ;;; # Check for issues
 ;;; ## Checks
+(def edubaseall-send-map
+  "GIAS SEND map to use (if not using the default)"
+  (delay (gias/edubaseall-send->map)))
+
+(def sen2-estab-min-expected-placed
+  "Map of issue thresholds for minimum number of placements expected for selected `sen2-estab`s."
+  (delay
+    (->
+     ;; Replace the following template dataset with one containing capacities to consider
+     (tc/dataset [{:urn                           "000000"
+                   :ukprn                         nil
+                   :sen-unit-indicator            false
+                   :resourced-provision-indicator false
+                   :sen-setting                   nil
+                   :capacity                      00}])
+     ;; Set threshold to flag if LA usage is below 75% of the capacity
+     (tc/map-columns :num-placed-check-threshold [:capacity] #(-> % (* 0.75) Math/floor int))
+     ;; Turn into a map
+     (->> ((juxt #(-> %
+                      (tc/select-columns sen2-blade-plans-placements/sen2-estab-keys)
+                      (tc/rows :as-maps))
+                 :num-placed-check-threshold))
+          (apply zipmap)))))
+
+(def plans-placements-checks-to-omit
+  "Checks to omit"
+  [:issue-missing-census-year                  ; Guaranteed non-missing by derivation.
+   :issue-missing-census-date                  ; Guaranteed non-missing by derivation.
+   :issue-unknown-age-at-start-of-school-year  ; Covered by check `:issue-missing-ncy-nominal`
+   :issue-not-send-age                         ; Covered by check `:issue-invalid-ncy-nominal`
+   :issue-placement-detail-missing-sen2-estab  ; Covered by check `:issue-missing-sen2-estab`
+   ])
+
 (def checks
-  "Definitions for checks for issues in dataset of plans & placements on census dates."
-  (sen2-blade-plans-placements/checks))
+  "Definitions of checks for issues in dataset of plans & placements on census dates."
+  (delay (sen2-blade-plans-placements/checks
+          {:edubaseall-send-map            @edubaseall-send-map
+           :sen2-estab-min-expected-placed @sen2-estab-min-expected-placed
+           :checks-to-omit                 plans-placements-checks-to-omit})))
 
 
 ;;; ## Run checks
@@ -61,26 +107,32 @@
    for rows with issues flagged by `checks`,
    with issue flag columns,
    and blank columns for manual updates."
-  (delay (sen2-blade-plans-placements/issues->ds @plans-placements-on-census-dates
-                                                 checks)))
+  (delay (-> @plans-placements-on-census-dates
+             (sen2-blade-plans-placements/issues->ds
+              @checks
+              {:sen2-blade-module-cols-to-select sen2-blade-module-cols-to-select})
+             (as-> $ (tc/set-dataset-name $ (str (tc/dataset-name $) sen2-blade-suffix))))))
 
 (def plans-placements-on-census-dates-issues-col-name->label
   "Column labels for display."
   (delay (sen2-blade-plans-placements/plans-placements-on-census-dates-issues-col-name->label
           {:plans-placements-on-census-dates-col-name->label @plans-placements-on-census-dates-col-name->label
-           :checks                                           checks})))
+           :checks                                           @checks})))
 
+(comment ;; EDA: Summary of issues with plans & placements
+  (-> @plans-placements-on-census-dates-issues
+      sen2-blade-plans-placements/drop-falsey-issue-columns
+      (sen2-blade-plans-placements/summarise-issues (merge @checks sen2-blade-plans-placements/checks-total-issues))
+      (vary-meta assoc :print-index-range 1000))
 
-;;; ## Write issues file
-(comment
-  (let [ds              @plans-placements-on-census-dates-issues
-        file-name-stem  (tc/dataset-name ds)
-        col-name->label @plans-placements-on-census-dates-issues-col-name->label]
-    (tc/write! (tc/dataset {:column-number (iterate inc 1)
-                            :column-name   (map name (tc/column-names ds))
-                            :column-label  (map col-name->label (tc/column-names ds))})
-               (str out-dir file-name-stem "-col-labels.csv"))
-    (tc/write! ds
-               (str out-dir file-name-stem ".csv")))
+  )
+
+(comment ;; Write issues file (and column labels file)
+  (do (-> @plans-placements-on-census-dates-issues
+          (#(tc/write! % (str out-dir (tc/dataset-name %) ".csv"))))
+      (-> @plans-placements-on-census-dates-issues
+          (sen2-blade-plans-placements/csv-col-labels-dataset
+           @plans-placements-on-census-dates-issues-col-name->label)
+          (#(tc/write! % (str out-dir (tc/dataset-name %) ".csv")))))
   )
 

--- a/templates/plans_placements.clj
+++ b/templates/plans_placements.clj
@@ -3,8 +3,9 @@
   (:require [tablecloth.api :as tc]
             [witan.gias :as gias]
             [witan.sen2 :as sen2]
+            [witan.sen2.return.person-level.blade.plans-placements :as sen2-blade-plans-placements]
             [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
-            [witan.sen2.return.person-level.blade.plans-placements :as sen2-blade-plans-placements]))
+            ))
 
 
 ;;; # Parameters

--- a/templates/plans_placements_eda.clj
+++ b/templates/plans_placements_eda.clj
@@ -23,7 +23,11 @@
 (def workpackage-name "witan.sen2")
 (def out-dir "Output directory" "./tmp/")
 
-^#::clerk{:visibility {:result :show},:viewer clerk/md, :no-cache true} ; Notebook header
+(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
+
+{::clerk/visibility {:result :show}}
+
+^#::clerk{:viewer clerk/md, :no-cache true} ; Notebook header
 (str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
      (format "# %s SEND %s  \n" client-name workpackage-name)
      (format "`%s`\n\n" *ns*)
@@ -31,13 +35,6 @@
      (format "Produced: `%s`\n\n"  (.format (LocalDateTime/now)
                                             (DateTimeFormatter/ofPattern "dd-MMM-uuuu HH:mm:ss"
                                                                          (java.util.Locale. "en_GB")))))
-
-(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
-{::clerk/visibility {:result :show}}
-
-
-
-
 ;;; # Plans & Placements EDA
 ;; 1. Get the SEN2 Blade.
 ;; 2. Extract plans & placements on census dates.

--- a/templates/plans_placements_eda.clj
+++ b/templates/plans_placements_eda.clj
@@ -6,7 +6,7 @@
                       :page-size            nil
                       :auto-expand-results? true
                       :budget               nil}
-  (:require [clojure.string :as string]
+  (:require [clojure.string :as str]
             [nextjournal.clerk :as clerk]
             [tablecloth.api :as tc]
             [witan.sen2.return.person-level.dictionary :as sen2-dictionary]
@@ -18,7 +18,6 @@
             )
   (:import [java.time LocalDateTime]
            [java.time.format DateTimeFormatter]))
-
 
 (def client-name      "Mastodon C")
 (def workpackage-name "witan.sen2")
@@ -203,7 +202,7 @@
 
 ^#::clerk{:viewer clerk/md}
 (str "This notebook (as HTML)"
-     ":  \n`" out-dir (string/replace (str *ns*) #"^.*\." "") ".html`")
+     ":  \n`" out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html`")
 
 ^#::clerk{:visibility {:result :hide}}
 (comment ;; clerk build to a standalone html file

--- a/templates/plans_placements_eda.clj
+++ b/templates/plans_placements_eda.clj
@@ -158,7 +158,7 @@
 ;; [explore-education-statistics.service.gov.uk](https://explore-education-statistics.service.gov.uk/find-statistics/education-health-and-care-plans):
 ^{::clerk/viewer (partial clerk/table {::clerk/width :full})}
 (-> @plans-placements/plans-placements-on-census-dates
-    (sen2-blade-plans-placements/plan-placement-stats la-name)
+    (sen2-blade-plans-placements/plan-placement-module-summary-with-caseload la-name)
     (tc/update-columns :census-date (partial map #(.format % (DateTimeFormatter/ofPattern
                                                               "dd-MMM-uuuu"
                                                               (java.util.Locale. "en_GB")))))

--- a/templates/sen2_blade_csv.clj
+++ b/templates/sen2_blade_csv.clj
@@ -35,7 +35,15 @@
   (delay (sen2-blade-csv/file-paths->ds-map file-paths)))
 
 
-;;; ## Bring in defs required for EDA/documentation
+
+;;; # Extract return year
+(def return-year
+  "SEN2 return year"
+  (delay (->> @ds-map :sen2 :year (apply max))))
+
+
+
+;;; # Bring in defs required for EDA/documentation
 ;; Not required if not doing a sen2-blade-eda.
 (def table-id-ds
   "Dataset of `:*table-id` key relationships."

--- a/templates/sen2_blade_csv.clj
+++ b/templates/sen2_blade_csv.clj
@@ -9,12 +9,14 @@
 (def data-dir
   "Directory containing SEN2 Blade export files"
   #_"./data/example-sen2-blade-csv-export-2023/"
-  "./data/example-sen2-blade-csv-export-2024/")
+  "./data/example-sen2-blade-csv-export-2024/"
+  #_"./data/example-sen2-blade-csv-export-2025/")
 
 (def export-date-string
   "Date (string) of COLLECT `Blade-Export`"
   #_"31-03-2023"
-  "18-04-2024")
+  "18-04-2024"
+  #_"07-03-2025")
 
 
 

--- a/templates/sen2_blade_csv_eda.clj
+++ b/templates/sen2_blade_csv_eda.clj
@@ -17,7 +17,10 @@
 (def workpackage-name "witan.sen2")
 (def out-dir "Output directory" "./tmp/")
 
-^#::clerk{:visibility {:result :show},:viewer clerk/md, :no-cache true} ; Notebook header
+(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
+
+{::clerk/visibility {:result :show}}
+^#::clerk{:viewer clerk/md, :no-cache true} ; Notebook header
 (str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
      (format "# %s SEND %s  \n" client-name workpackage-name)
      (format "`%s`\n\n" *ns*)
@@ -25,13 +28,6 @@
      (format "Produced: `%s`\n\n"  (.format (java.time.LocalDateTime/now)
                                             (java.time.format.DateTimeFormatter/ofPattern "dd-MMM-uuuu HH:mm:ss"
                                                                                           (java.util.Locale. "en_GB")))))
-
-(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
-{::clerk/visibility {:result :show}}
-
-
-
-
 ;;; # SEN2 Blade EDA
 ;;; ## Parameters
 ;;; ### Output directory

--- a/templates/sen2_blade_csv_eda.clj
+++ b/templates/sen2_blade_csv_eda.clj
@@ -9,9 +9,10 @@
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
-            [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]
-            [witan.send.adroddiad.clerk.html :as chtml]))
+            [witan.send.adroddiad.clerk.html :as chtml]
+            [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
+            ))
 
 (def client-name      "Mastodon C")
 (def workpackage-name "witan.sen2")

--- a/templates/sen2_blade_csv_eda.clj
+++ b/templates/sen2_blade_csv_eda.clj
@@ -6,13 +6,12 @@
                       :page-size            nil
                       :auto-expand-results? true
                       :budget               nil}
-  (:require [clojure.string :as string]
+  (:require [clojure.string :as str]
             [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
             [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]
             [witan.send.adroddiad.clerk.html :as chtml]))
-
 
 (def client-name      "Mastodon C")
 (def workpackage-name "witan.sen2")
@@ -110,7 +109,7 @@
 ;;; ## Output
 ^#::clerk{:viewer clerk/md}
 (str "This notebook (as HTML)"
-     ":  \n`" out-dir (string/replace (str *ns*) #"^.*\." "") ".html`")
+     ":  \n`" out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html`")
 
 ^#::clerk{:visibility {:result :hide}}
 (comment ;; clerk build to a standalone html file

--- a/templates/sen2_blade_csv_eda.clj
+++ b/templates/sen2_blade_csv_eda.clj
@@ -1,12 +1,12 @@
 (ns sen2-blade-csv-eda
   "EDA of SEN2 Blade read from COLLECT Blade CSV export."
   #:nextjournal.clerk{:toc                  true
-                      :visibility           {:code :hide, :result :hide}
+                      :visibility           {:code   :hide
+                                             :result :hide}
                       :page-size            nil
                       :auto-expand-results? true
                       :budget               nil}
-  (:require [clojure.string :as string]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
             [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]))
@@ -102,19 +102,3 @@
 ;; Note: Except for `person`, OK if not a unique key without `requests-table-id`,
 (sen2-blade-eda/report-unique-keys @sen2-blade/ds-map)
 (sen2-blade-eda/report-table-keys)
-
-
-
-
-^#::clerk{:visibility {:result :hide}}
-(comment ;; clerk build
-  (let [in-path  (str "templates/" (clojure.string/replace (str *ns*) #"\.|-" {"." "/" "-" "_"}) ".clj")
-        out-path (str out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html")]
-    (clerk/build! {:paths      [in-path]
-                   :ssr        true
-                   #_#_:bundle true         ; clerk v0.15.957
-                   :package    :single-file ; clerk v0.16.1016
-                   :out-path   "."})
-    (.renameTo (io/file "./index.html") (io/file out-path)))
-
-  )

--- a/templates/sen2_blade_csv_eda.clj
+++ b/templates/sen2_blade_csv_eda.clj
@@ -6,10 +6,12 @@
                       :page-size            nil
                       :auto-expand-results? true
                       :budget               nil}
-  (:require [clojure.java.io :as io]
+  (:require [clojure.string :as string]
+            [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]
             [sen2-blade-csv :as sen2-blade] ; <- replace with workpackage specific version
-            [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]))
+            [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]
+            [witan.send.adroddiad.clerk.html :as chtml]))
 
 
 (def client-name      "Mastodon C")
@@ -102,3 +104,18 @@
 ;; Note: Except for `person`, OK if not a unique key without `requests-table-id`,
 (sen2-blade-eda/report-unique-keys @sen2-blade/ds-map)
 (sen2-blade-eda/report-table-keys)
+
+
+
+;;; ## Output
+^#::clerk{:viewer clerk/md}
+(str "This notebook (as HTML)"
+     ":  \n`" out-dir (string/replace (str *ns*) #"^.*\." "") ".html`")
+
+^#::clerk{:visibility {:result :hide}}
+(comment ;; clerk build to a standalone html file
+  (when (chtml/build-ns! *ns* {:project-path "./templates"
+                               :out-dir      "./tmp"})
+    (clerk/show! (chtml/ns->filepath *ns* "./templates")))
+
+  )

--- a/templates/sen2_blade_template.clj
+++ b/templates/sen2_blade_template.clj
@@ -18,7 +18,15 @@
   (delay (sen2-blade-template/template-file->ds-map template-filepath)))
 
 
-;;; ## Bring in defs required for EDA/documentation
+
+;;; # Extract return year
+(def return-year
+  "SEN2 return year"
+  (delay (->> @ds-map :sen2 :year (apply max))))
+
+
+
+;;; # Bring in defs required for EDA/documentation
 ;; Not required if not doing a sen2-blade-eda.
 (def module-titles
   sen2-blade-template/module-titles)

--- a/templates/sen2_blade_template_eda.clj
+++ b/templates/sen2_blade_template_eda.clj
@@ -1,15 +1,16 @@
 (ns sen2-blade-template-eda
   "EDA of SEN2 Blade read from Excel submission template."
   #:nextjournal.clerk{:toc                  true
-                      :visibility           {:code :hide, :result :hide}
+                      :visibility           {:code   :hide
+                                             :result :hide}
                       :page-size            nil
                       :auto-expand-results? true
                       :budget               nil}
-  (:require [clojure.string :as string]
-            [clojure.java.io :as io]
+  (:require [clojure.string :as str]
             [nextjournal.clerk :as clerk]
             [sen2-blade-template :as sen2-blade] ; <- replace with workpackage specific version
-            [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]))
+            [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]
+            [witan.send.adroddiad.clerk.html :as chtml]))
 
 (def client-name      "Mastodon C")
 (def workpackage-name "witan.sen2")
@@ -82,16 +83,16 @@
 
 
 
+;;; ## Output
+^#::clerk{:viewer clerk/md}
+(str "This notebook (as HTML)"
+     ":  \n`" out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html`")
 
-^{::clerk/visibility {:result :hide}}
-(comment ;; clerk build
-  (let [in-path  (str "templates/" (clojure.string/replace (str *ns*) #"\.|-" {"." "/" "-" "_"}) ".clj")
-        out-path (str out-dir (clojure.string/replace (str *ns*) #"^.*\." "") ".html")]
-    (clerk/build! {:paths      [in-path]
-                   :ssr        true
-                   #_#_:bundle true         ; clerk v0.15.957
-                   :package    :single-file ; clerk v0.16.1016
-                   :out-path   "."})
-    (.renameTo (io/file "./index.html") (io/file out-path)))
+^#::clerk{:visibility {:result :hide}}
+(comment ;; clerk build to a standalone html file
+  (when (chtml/build-ns! *ns* {:project-path "./templates"
+                               :out-dir      "./tmp"})
+    (clerk/show! (chtml/ns->filepath *ns* "./templates")))
 
   )
+

--- a/templates/sen2_blade_template_eda.clj
+++ b/templates/sen2_blade_template_eda.clj
@@ -16,7 +16,11 @@
 (def workpackage-name "witan.sen2")
 (def out-dir "Output directory" "./tmp/")
 
-^#::clerk{:visibility {:result :show},:viewer clerk/md, :no-cache true} ; Notebook header
+(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
+
+{::clerk/visibility {:result :show}}
+
+^#::clerk{:viewer clerk/md, :no-cache true} ; Notebook header
 (str "![Mastodon C](https://www.mastodonc.com/wp-content/themes/MastodonC-2018/dist/images/logo_mastodonc.png)  \n"
      (format "# %s SEND %s  \n" client-name workpackage-name)
      (format "`%s`\n\n" *ns*)
@@ -24,13 +28,6 @@
      (format "Produced: `%s`\n\n"  (.format (java.time.LocalDateTime/now)
                                             (java.time.format.DateTimeFormatter/ofPattern "dd-MMM-uuuu HH:mm:ss"
                                                                                           (java.util.Locale. "en_GB")))))
-
-(defn doc-var [v] (format "%s:  \n`%s`." (-> v meta :doc) (var-get v)))
-{::clerk/visibility {:result :show}}
-
-
-
-
 ;;; # SEN2 Blade EDA
 ;;; ## Parameters
 ;;; ### Output directory

--- a/templates/sen2_blade_template_eda.clj
+++ b/templates/sen2_blade_template_eda.clj
@@ -8,9 +8,10 @@
                       :budget               nil}
   (:require [clojure.string :as str]
             [nextjournal.clerk :as clerk]
-            [sen2-blade-template :as sen2-blade] ; <- replace with workpackage specific version
+            [witan.send.adroddiad.clerk.html :as chtml]
             [witan.sen2.return.person-level.blade.eda :as sen2-blade-eda]
-            [witan.send.adroddiad.clerk.html :as chtml]))
+            [sen2-blade-template :as sen2-blade] ; <- replace with workpackage specific version
+            ))
 
 (def client-name      "Mastodon C")
 (def workpackage-name "witan.sen2")


### PR DESCRIPTION
Update templates for SEN2 blade processing, extraction & checking of plans-and-placements, and EDA thereof: bring up to date for improved checks and move common code to the main library namespaces.

I suggest reviewing the updates to the library namespaces (under `./src`) first, considering the diffs, and then review the templates (under `./templates`) considering the final file rather (as reviewing the diffs won't give you the overall picture). If you want to run the template namespaces/notebooks then you'll need links to the example data used: let me know if you want these.